### PR TITLE
ลดดีเลย์สตรีม ffmpeg ด้วยออปชัน nobuffer

### DIFF
--- a/camera_worker.py
+++ b/camera_worker.py
@@ -90,6 +90,8 @@ class CameraWorker:
 
             cmd += [
                 "-fflags", "+discardcorrupt",  # ทิ้งเฟรม/แพ็กเก็ตเสีย
+                "-flags", "low_delay",  # ลดการหน่วงของสตรีม
+                "-fflags", "nobuffer",  # ไม่สะสมเฟรมในบัฟเฟอร์
                 "-i", str(src),
                 "-map", "0:v:0",
                 "-an",


### PR DESCRIPTION
## สรุป
- เพิ่มออปชัน `low_delay` และ `nobuffer` ให้ ffmpeg เพื่อไม่สะสมเฟรมและลดดีเลย์ของสตรีม

## การทดสอบ
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c622b11f54832baf5e9d6d2134cbf7