### PR TITLE
ลดดีเลย์สตรีมโดยตัดคิวเฟรมค้าง

### DIFF
--- a/app.py
+++ b/app.py
@@ -788,7 +788,10 @@ async def ws(cam_id: str):
             if frame_bytes is None:
                 await websocket.close(code=1000)
                 break
-            await websocket.send(frame_bytes)
+            try:
+                await asyncio.wait_for(websocket.send(frame_bytes), timeout=1)
+            except asyncio.TimeoutError:
+                break
     except ConnectionClosed:
         pass
     finally:
@@ -810,7 +813,10 @@ async def ws_roi(cam_id: str):
             if frame_bytes is None:
                 await websocket.close(code=1000)
                 break
-            await websocket.send(frame_bytes)
+            try:
+                await asyncio.wait_for(websocket.send(frame_bytes), timeout=1)
+            except asyncio.TimeoutError:
+                break
     except ConnectionClosed:
         pass
     finally:
@@ -832,7 +838,10 @@ async def ws_roi_result(cam_id: str):
             if data is None:
                 await websocket.close(code=1000)
                 break
-            await websocket.send(data)
+            try:
+                await asyncio.wait_for(websocket.send(data), timeout=1)
+            except asyncio.TimeoutError:
+                break
     except ConnectionClosed:
         pass
     finally:

--- a/templates/partials/inference_content.html
+++ b/templates/partials/inference_content.html
@@ -61,6 +61,8 @@
         const intervalInput = getEl('intervalInput');
         let logTimer;
         let currentLogSource;
+        let frameTimer;
+        let lastFrameTime = 0;
         intervalInput.value = localStorage.getItem(`${cellId}-interval`) || '1';
 
         const formatTs = ts => {
@@ -329,6 +331,10 @@
                 roiSocket.close();
                 roiSocket = null;
             }
+            if (frameTimer) {
+                clearInterval(frameTimer);
+                frameTimer = null;
+            }
             stopLogUpdates();
             // clear last frame and related data to free memory
             if (video.src && video.src.startsWith('blob:')) {
@@ -348,13 +354,27 @@
         function openSocket() {
             socket = new WebSocket(`ws://${location.host}/ws/${cam}`);
             socket.binaryType = 'arraybuffer';
+            lastFrameTime = Date.now();
             socket.onmessage = function(event) {
+                lastFrameTime = Date.now();
                 if (video.src && video.src.startsWith('blob:')) {
                     URL.revokeObjectURL(video.src);
                 }
                 const blob = new Blob([event.data], { type: 'image/jpeg' });
                 video.src = URL.createObjectURL(blob);
             };
+            socket.onclose = () => {
+                if (frameTimer) {
+                    clearInterval(frameTimer);
+                    frameTimer = null;
+                }
+            };
+            frameTimer = setInterval(() => {
+                if (Date.now() - lastFrameTime > 2000) {
+                    try { socket.close(); } catch (e) {}
+                    openSocket();
+                }
+            }, 1000);
         }
 
         function openRoiSocket() {

--- a/templates/partials/inference_page_content.html
+++ b/templates/partials/inference_page_content.html
@@ -56,6 +56,8 @@ function createController(cellId){
     const logRoiSelect=getEl('logRoiSelect');
     let rois=[];
     let logTimer;
+    let frameTimer;
+    let lastFrameTime=0;
 
     function populateLogRoiSelect(){
         logRoiSelect.innerHTML='';
@@ -217,13 +219,24 @@ function createController(cellId){
     function openSocket(){
         socket=new WebSocket(`ws://${location.host}/ws/${cam}`);
         socket.binaryType='arraybuffer';
+        lastFrameTime=Date.now();
         socket.onmessage=event=>{
+            lastFrameTime=Date.now();
             if(video.src && video.src.startsWith('blob:')){
                 URL.revokeObjectURL(video.src);
             }
             const blob=new Blob([event.data],{type:'image/jpeg'});
             video.src=URL.createObjectURL(blob);
         };
+        socket.onclose=()=>{
+            if(frameTimer){clearInterval(frameTimer);frameTimer=null;}
+        };
+        frameTimer=setInterval(()=>{
+            if(Date.now()-lastFrameTime>2000){
+                try{socket.close();}catch(e){}
+                openSocket();
+            }
+        },1000);
     }
 
     function openRoiSocket(){
@@ -327,6 +340,7 @@ function createController(cellId){
         await fetchWithStatus(`/stop_inference/${cam}`,{method:'POST'});
         if(socket){socket.close();socket=null;}
         if(roiSocket){roiSocket.close();roiSocket=null;}
+        if(frameTimer){clearInterval(frameTimer);frameTimer=null;}
         stopLogUpdates();
         if(video.src && video.src.startsWith('blob:')){
             URL.revokeObjectURL(video.src);


### PR DESCRIPTION
## Summary
- ป้องกัน WebSocket ค้างโดยตั้ง timeout ระหว่างส่งเฟรม ทั้งสตรีมหลักและ ROI
- เพิ่มกลไกฝั่งเว็บให้ตรวจจับเมื่อเฟรมไม่มาและเชื่อมต่อใหม่อัตโนมัติ เพื่อตัดเฟรมค้างและแสดงภาพปัจจุบัน

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c62fa06168832bb19f71f2b331f150