### PR TITLE
แก้ UI สตรีมให้ขึ้นจอดำเมื่อเฟรมค้าง

### DIFF
--- a/templates/partials/inference_content.html
+++ b/templates/partials/inference_content.html
@@ -50,6 +50,14 @@
         const getEl = suffix => document.getElementById(`${cellId}-${suffix}`);
         const video = getEl('video');
         video.onload = () => URL.revokeObjectURL(video.src);
+        const BLACK_FRAME = 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/wwAAgMBgNUNGMkAAAAASUVORK5CYII=';
+        function showBlackScreen() {
+            if (video.src && video.src.startsWith('blob:')) {
+                URL.revokeObjectURL(video.src);
+            }
+            video.src = BLACK_FRAME;
+        }
+        showBlackScreen();
         const startButton = getEl('startButton');
         const stopButton = getEl('stopButton');
         const statusEl = getEl('status');
@@ -337,10 +345,7 @@
             }
             stopLogUpdates();
             // clear last frame and related data to free memory
-            if (video.src && video.src.startsWith('blob:')) {
-                URL.revokeObjectURL(video.src);
-            }
-            video.src = '';
+            showBlackScreen();
             rois = [];
             allRois = [];
             roiGrid.innerHTML = '';
@@ -364,6 +369,7 @@
                 video.src = URL.createObjectURL(blob);
             };
             socket.onclose = () => {
+                showBlackScreen();
                 if (frameTimer) {
                     clearInterval(frameTimer);
                     frameTimer = null;
@@ -371,6 +377,7 @@
             };
             frameTimer = setInterval(() => {
                 if (Date.now() - lastFrameTime > 2000) {
+                    showBlackScreen();
                     try { socket.close(); } catch (e) {}
                     openSocket();
                 }

--- a/templates/partials/inference_page_content.html
+++ b/templates/partials/inference_page_content.html
@@ -49,6 +49,14 @@ function createController(cellId){
     const getEl=suffix=>document.getElementById(`${cellId}-${suffix}`);
     const video=getEl('video');
     video.onload=()=>URL.revokeObjectURL(video.src);
+    const BLACK_FRAME='data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/wwAAgMBgNUNGMkAAAAASUVORK5CYII=';
+    function showBlackScreen(){
+        if(video.src && video.src.startsWith('blob:')){
+            URL.revokeObjectURL(video.src);
+        }
+        video.src=BLACK_FRAME;
+    }
+    showBlackScreen();
     const pageNameEl=getEl('pageName');
     const scoreTableBody=getEl('pageScoresBody');
     const roiGrid=getEl('rois');
@@ -229,10 +237,12 @@ function createController(cellId){
             video.src=URL.createObjectURL(blob);
         };
         socket.onclose=()=>{
+            showBlackScreen();
             if(frameTimer){clearInterval(frameTimer);frameTimer=null;}
         };
         frameTimer=setInterval(()=>{
             if(Date.now()-lastFrameTime>2000){
+                showBlackScreen();
                 try{socket.close();}catch(e){}
                 openSocket();
             }
@@ -342,10 +352,7 @@ function createController(cellId){
         if(roiSocket){roiSocket.close();roiSocket=null;}
         if(frameTimer){clearInterval(frameTimer);frameTimer=null;}
         stopLogUpdates();
-        if(video.src && video.src.startsWith('blob:')){
-            URL.revokeObjectURL(video.src);
-        }
-        video.src='';
+        showBlackScreen();
         rois=[];
         populateLogRoiSelect();
         roiGrid.innerHTML='';

--- a/templates/roi_selection.html
+++ b/templates/roi_selection.html
@@ -56,6 +56,16 @@
         const pickBtn = document.getElementById("pickBtn");
         const rectBtn = document.getElementById("rectBtn");
         const pageBtn = document.getElementById("pageBtn");
+        let frameTimer;
+        let lastFrameTime = 0;
+        const BLACK_FRAME = 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/wwAAgMBgNUNGMkAAAAASUVORK5CYII=';
+        function showBlackScreen() {
+            if (video.src && video.src.startsWith('blob:')) {
+                URL.revokeObjectURL(video.src);
+            }
+            video.src = BLACK_FRAME;
+        }
+        showBlackScreen();
         function setMode(mode, type = 'roi') {
             currentMode = mode;
             currentType = type;
@@ -150,18 +160,35 @@
         function openSocket() {
             socket = new WebSocket(`ws://${location.host}/ws_roi/${cam}`);
             socket.binaryType = "arraybuffer";
+            lastFrameTime = Date.now();
             socket.onmessage = function(event) {
+                lastFrameTime = Date.now();
+                if (video.src && video.src.startsWith('blob:')) {
+                    URL.revokeObjectURL(video.src);
+                }
                 const blob = new Blob([event.data], { type: "image/jpeg" });
                 video.src = URL.createObjectURL(blob);
             };
             socket.onclose = function() {
+                showBlackScreen();
                 socket = null;
+                if (frameTimer) {
+                    clearInterval(frameTimer);
+                    frameTimer = null;
+                }
                 isStreaming = false;
                 stopBtn.disabled = true;
                 startBtn.disabled = false;
                 hasStarted = false;
                 console.log("ROI stream closed");
             };
+            frameTimer = setInterval(() => {
+                if (Date.now() - lastFrameTime > 2000) {
+                    showBlackScreen();
+                    try { socket.close(); } catch (e) {}
+                    openSocket();
+                }
+            }, 1000);
         }
 
         async function checkStatus() {
@@ -235,11 +262,16 @@
                 socket.close();
                 socket = null;
             }
+            if (frameTimer) {
+                clearInterval(frameTimer);
+                frameTimer = null;
+            }
             try {
                 await fetch(`/stop_roi_stream/${cam}`, { method: 'POST', keepalive: true });
             } catch (err) {
                 console.error('Failed to stop ROI stream', err);
             }
+            showBlackScreen();
             isStreaming = false;
             hasStarted = false;
             stopBtn.disabled = true;


### PR DESCRIPTION
## Summary
- แสดงเฟรมสีดำเมื่อหยุดสตรีมหรือเฟรมไม่อัปเดตในหน้า inference, inference_page และ ROI selection
- ตรวจจับการค้างของ WebSocket แล้วเชื่อมต่อใหม่พร้อมรีเซ็ตภาพเป็นสีดำ

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c63f963444832bb219680d1acabd44