### PR TITLE
Fix stop button state on ROI streaming page

### DIFF
--- a/templates/roi_selection.html
+++ b/templates/roi_selection.html
@@ -176,10 +176,6 @@
                     clearInterval(frameTimer);
                     frameTimer = null;
                 }
-                isStreaming = false;
-                stopBtn.disabled = true;
-                startBtn.disabled = false;
-                hasStarted = false;
                 console.log("ROI stream closed");
             };
             frameTimer = setInterval(() => {


### PR DESCRIPTION
## Summary
- keep Start/Stop button state when ROI stream reconnects automatically

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c641fda62c832bbb1ca93abf41a2aa