### PR TITLE
Remove black frame placeholder on stream interruption

### DIFF
--- a/templates/partials/inference_content.html
+++ b/templates/partials/inference_content.html
@@ -50,12 +50,12 @@
         const getEl = suffix => document.getElementById(`${cellId}-${suffix}`);
         const video = getEl('video');
         video.onload = () => URL.revokeObjectURL(video.src);
-        const BLACK_FRAME = 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/wwAAgMBgNUNGMkAAAAASUVORK5CYII=';
         function showBlackScreen() {
             if (video.src && video.src.startsWith('blob:')) {
                 URL.revokeObjectURL(video.src);
             }
-            video.src = BLACK_FRAME;
+            video.removeAttribute('src');
+            video.style.display = 'none';
         }
         showBlackScreen();
         const startButton = getEl('startButton');
@@ -366,6 +366,9 @@
                     URL.revokeObjectURL(video.src);
                 }
                 const blob = new Blob([event.data], { type: 'image/jpeg' });
+                if (video.style.display === 'none') {
+                    video.style.display = '';
+                }
                 video.src = URL.createObjectURL(blob);
             };
             socket.onclose = () => {

--- a/templates/partials/inference_page_content.html
+++ b/templates/partials/inference_page_content.html
@@ -49,12 +49,12 @@ function createController(cellId){
     const getEl=suffix=>document.getElementById(`${cellId}-${suffix}`);
     const video=getEl('video');
     video.onload=()=>URL.revokeObjectURL(video.src);
-    const BLACK_FRAME='data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/wwAAgMBgNUNGMkAAAAASUVORK5CYII=';
     function showBlackScreen(){
         if(video.src && video.src.startsWith('blob:')){
             URL.revokeObjectURL(video.src);
         }
-        video.src=BLACK_FRAME;
+        video.removeAttribute('src');
+        video.style.display='none';
     }
     showBlackScreen();
     const pageNameEl=getEl('pageName');
@@ -234,6 +234,7 @@ function createController(cellId){
                 URL.revokeObjectURL(video.src);
             }
             const blob=new Blob([event.data],{type:'image/jpeg'});
+            if(video.style.display==='none'){video.style.display='';}
             video.src=URL.createObjectURL(blob);
         };
         socket.onclose=()=>{

--- a/templates/roi_selection.html
+++ b/templates/roi_selection.html
@@ -58,12 +58,12 @@
         const pageBtn = document.getElementById("pageBtn");
         let frameTimer;
         let lastFrameTime = 0;
-        const BLACK_FRAME = 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/wwAAgMBgNUNGMkAAAAASUVORK5CYII=';
         function showBlackScreen() {
             if (video.src && video.src.startsWith('blob:')) {
                 URL.revokeObjectURL(video.src);
             }
-            video.src = BLACK_FRAME;
+            video.removeAttribute('src');
+            video.style.display = 'none';
         }
         showBlackScreen();
         function setMode(mode, type = 'roi') {
@@ -167,6 +167,9 @@
                     URL.revokeObjectURL(video.src);
                 }
                 const blob = new Blob([event.data], { type: "image/jpeg" });
+                if (video.style.display === 'none') {
+                    video.style.display = '';
+                }
                 video.src = URL.createObjectURL(blob);
             };
             socket.onclose = function() {


### PR DESCRIPTION
## Summary
- Hide video element instead of showing black placeholder when stream stops
- Restore video visibility when frames arrive

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c6461ba5bc832b96ac9827ea567c7b