### PR TITLE
ลดดีเลย์สตรีมวิดีโอโดยทิ้งเฟรมเก่า

### DIFF
--- a/templates/partials/inference_content.html
+++ b/templates/partials/inference_content.html
@@ -71,6 +71,25 @@
         let currentLogSource;
         let frameTimer;
         let lastFrameTime = 0;
+        let latestFrameData;
+        let framePending = false;
+
+        function displayFrame() {
+            if (latestFrameData) {
+                const data = latestFrameData;
+                latestFrameData = null;
+                if (video.src && video.src.startsWith('blob:')) {
+                    URL.revokeObjectURL(video.src);
+                }
+                const blob = new Blob([data], { type: 'image/jpeg' });
+                video.src = URL.createObjectURL(blob);
+            }
+            if (latestFrameData) {
+                requestAnimationFrame(displayFrame);
+            } else {
+                framePending = false;
+            }
+        }
         intervalInput.value = localStorage.getItem(`${cellId}-interval`) || '1';
 
         const formatTs = ts => {
@@ -362,11 +381,11 @@
             lastFrameTime = Date.now();
             socket.onmessage = function(event) {
                 lastFrameTime = Date.now();
-                if (video.src && video.src.startsWith('blob:')) {
-                    URL.revokeObjectURL(video.src);
+                latestFrameData = event.data;
+                if (!framePending) {
+                    framePending = true;
+                    requestAnimationFrame(displayFrame);
                 }
-                const blob = new Blob([event.data], { type: 'image/jpeg' });
-                video.src = URL.createObjectURL(blob);
             };
             socket.onclose = () => {
                 showBlackScreen();

--- a/templates/roi_selection.html
+++ b/templates/roi_selection.html
@@ -56,8 +56,27 @@
         const pickBtn = document.getElementById("pickBtn");
         const rectBtn = document.getElementById("rectBtn");
         const pageBtn = document.getElementById("pageBtn");
-        let frameTimer;
-        let lastFrameTime = 0;
+    let frameTimer;
+    let lastFrameTime = 0;
+    let latestFrameData;
+    let framePending = false;
+
+    function displayFrame(){
+        if(latestFrameData){
+            const data = latestFrameData;
+            latestFrameData = null;
+            if(video.src && video.src.startsWith('blob:')){
+                URL.revokeObjectURL(video.src);
+            }
+            const blob = new Blob([data],{type:'image/jpeg'});
+            video.src = URL.createObjectURL(blob);
+        }
+        if(latestFrameData){
+            requestAnimationFrame(displayFrame);
+        }else{
+            framePending = false;
+        }
+    }
         const BLACK_FRAME = 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/wwAAgMBgNUNGMkAAAAASUVORK5CYII=';
         function showBlackScreen() {
             if (video.src && video.src.startsWith('blob:')) {
@@ -161,14 +180,14 @@
             socket = new WebSocket(`ws://${location.host}/ws_roi/${cam}`);
             socket.binaryType = "arraybuffer";
             lastFrameTime = Date.now();
-            socket.onmessage = function(event) {
-                lastFrameTime = Date.now();
-                if (video.src && video.src.startsWith('blob:')) {
-                    URL.revokeObjectURL(video.src);
-                }
-                const blob = new Blob([event.data], { type: "image/jpeg" });
-                video.src = URL.createObjectURL(blob);
-            };
+        socket.onmessage = function(event) {
+            lastFrameTime = Date.now();
+            latestFrameData = event.data;
+            if (!framePending) {
+                framePending = true;
+                requestAnimationFrame(displayFrame);
+            }
+        };
             socket.onclose = function() {
                 showBlackScreen();
                 socket = null;


### PR DESCRIPTION
## Summary
- ปรับสคริปต์หน้า inference และ ROI selection ให้แสดงเฉพาะเฟรมล่าสุดเสมอด้วยการใช้ตัวแปรเก็บเฟรมล่าสุดและ requestAnimationFrame

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c6c9506db0832ba45319ab2789668f