### PR TITLE
Clear residual ROI frames when starting or stopping stream

### DIFF
--- a/templates/roi_selection.html
+++ b/templates/roi_selection.html
@@ -107,6 +107,11 @@
             URL.revokeObjectURL(video.src);
         };
 
+        function clearFrame() {
+            video.src = '';
+            ctx.clearRect(0, 0, canvas.width, canvas.height);
+        }
+
         async function loadSources() {
             const res = await fetch("/source_list");
             const data = await res.json();
@@ -160,6 +165,7 @@
                 stopBtn.disabled = true;
                 startBtn.disabled = false;
                 hasStarted = false;
+                clearFrame();
                 console.log("ROI stream closed");
             };
         }
@@ -184,6 +190,7 @@
                 startBtn.disabled = false;
                 startBtn.textContent = "Start";
                 stopBtn.disabled = true;
+                clearFrame();
             }
         }
 
@@ -191,6 +198,7 @@
             if (hasStarted) return;
             if (isStreaming) return;
             hasStarted = true;
+            clearFrame();
             const name = document.getElementById("sourceSelect").value;
             if (!name) {
                 if (typeof showAlert === 'function') showAlert('Select source first', 'error');
@@ -244,6 +252,7 @@
             hasStarted = false;
             stopBtn.disabled = true;
             startBtn.disabled = false;
+            clearFrame();
         }
 
         frameContainer.addEventListener('click', (e) => {


### PR DESCRIPTION
## Summary
- reset ROI video and canvas when starting or stopping stream
- clear frame when ROI stream socket closes or status shows not running

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c6d8814778832b89af5e2d26b18301