### PR TITLE
Revoke previous blob URL to reduce ROI preview stutter

### DIFF
--- a/templates/roi_selection.html
+++ b/templates/roi_selection.html
@@ -157,6 +157,10 @@
             socket.binaryType = "arraybuffer";
             socket.onmessage = function(event) {
                 const blob = new Blob([event.data], { type: "image/jpeg" });
+                const oldUrl = video.src;
+                if (oldUrl && oldUrl.startsWith('blob:')) {
+                    URL.revokeObjectURL(oldUrl);
+                }
                 video.src = URL.createObjectURL(blob);
             };
             socket.onclose = function() {


### PR DESCRIPTION
## Summary
- reuse video blob URLs more efficiently by revoking the previous URL before assigning a new one in ROI selection page

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c74f058ae4832ba20d0f9b5779e6ba