### PR TITLE
ป้องกันการส่ง WebSocket หลังการปิด

### DIFF
--- a/app.py
+++ b/app.py
@@ -783,9 +783,12 @@ async def ws(cam_id: str):
             if frame_bytes is None:
                 await websocket.close(code=1000)
                 break
-            await websocket.send(frame_bytes)
-    except ConnectionClosed:
-        pass
+            if websocket.closed:
+                break
+            try:
+                await websocket.send(frame_bytes)
+            except (ConnectionClosed, RuntimeError):
+                break
     finally:
         with contextlib.suppress(Exception):
             await websocket.close()
@@ -800,9 +803,12 @@ async def ws_roi(cam_id: str):
             if frame_bytes is None:
                 await websocket.close(code=1000)
                 break
-            await websocket.send(frame_bytes)
-    except ConnectionClosed:
-        pass
+            if websocket.closed:
+                break
+            try:
+                await websocket.send(frame_bytes)
+            except (ConnectionClosed, RuntimeError):
+                break
     finally:
         with contextlib.suppress(Exception):
             await websocket.close()
@@ -817,9 +823,12 @@ async def ws_roi_result(cam_id: str):
             if data is None:
                 await websocket.close(code=1000)
                 break
-            await websocket.send(data)
-    except ConnectionClosed:
-        pass
+            if websocket.closed:
+                break
+            try:
+                await websocket.send(data)
+            except (ConnectionClosed, RuntimeError):
+                break
     finally:
         with contextlib.suppress(Exception):
             await websocket.close()


### PR DESCRIPTION
## Summary
- หยุดส่งข้อมูลเมื่อ WebSocket ปิดหรือเกิดข้อผิดพลาดใน ws, ws_roi และ ws_roi_result
- ใช้ try/except (ConnectionClosed, RuntimeError) ครอบ websocket.send เพื่อหยุดลูปอย่างปลอดภัย

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c75419c274832b90e3e5ec7595a388