### PR TITLE
ป้องกันการค้างเฟรมเดิมเมื่อสตรีมหน่วง

### DIFF
--- a/app.py
+++ b/app.py
@@ -424,8 +424,8 @@ async def read_and_queue_frame(
         return
     if frame_processor:
         frame = await frame_processor(frame)
-    if frame is None:
-        return
+        if frame is None:
+            return
     try:
         encoded, buffer = cv2.imencode('.jpg', frame, [int(cv2.IMWRITE_JPEG_QUALITY), 80])
     except Exception:

--- a/camera_worker.py
+++ b/camera_worker.py
@@ -328,19 +328,20 @@ class CameraWorker:
             if self.read_interval > 0:
                 time.sleep(self.read_interval)
 
-    async def read(self):
-        """อ่านเฟรมล่าสุดแบบ non-blocking"""
+    async def read(self, timeout: float = 0.1):
+        """อ่านเฟรมล่าสุดแบบ non-blocking; คืน ``None`` เมื่อรอเกินกำหนด"""
         try:
             return self._q.get_nowait()
         except Empty:
             pass
-        for _ in range(3):
+        deadline = time.monotonic() + timeout
+        while time.monotonic() < deadline:
             await asyncio.sleep(0.03)
             try:
                 return self._q.get_nowait()
             except Empty:
                 continue
-        return self._last_frame
+        return None
 
     async def stop(self) -> None:
         self._stop_evt.set()

--- a/tests/test_camera_worker_read_timeout.py
+++ b/tests/test_camera_worker_read_timeout.py
@@ -1,0 +1,24 @@
+import asyncio
+from queue import Queue
+
+def test_camera_worker_read_returns_none_on_timeout():
+    import sys, importlib
+    import camera_worker
+
+    worker = camera_worker.CameraWorker.__new__(camera_worker.CameraWorker)
+    worker._q = Queue(maxsize=1)
+    worker._last_frame = b"old"
+    worker._q.put_nowait(b"new")
+
+    async def run():
+        first = await worker.read()
+        worker._last_frame = first
+        second = await worker.read(timeout=0.05)
+        return first, second
+
+    first, second = asyncio.run(run())
+    assert first == b"new"
+    assert second is None
+
+    # cleanup so other tests can stub cv2 before importing camera_worker again
+    del sys.modules["camera_worker"]


### PR DESCRIPTION
## สรุป
- ปรับ `CameraWorker.read` ให้รอเฟรมใหม่และคืน `None` เมื่อหมดเวลา
- อัปเดต `read_and_queue_frame` ให้ข้ามการเข้ารหัสเมื่อไม่มีเฟรม
- เพิ่มการทดสอบกรณีเฟรม `None` และการไม่คืนค่าเฟรมเก่า

## การทดสอบ
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c76e16ef38832ba433d42a3ad6b770