### PR TITLE
Handle cancelled futures in ROI processing callback

### DIFF
--- a/app.py
+++ b/app.py
@@ -621,6 +621,8 @@ async def run_inference_loop(cam_id: str):
                                     result_text = str(result['text'])
                                 else:
                                     return
+                            except asyncio.CancelledError:
+                                return
                             except Exception:
                                 return
                             try:


### PR DESCRIPTION
## Summary
- ignore cancelled inference tasks to prevent spurious errors when stopping

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c7bd225c1c832ba51ae06c471c3fc4