### PR TITLE
refactor: remove unused imports

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,7 +1,7 @@
 import faulthandler
 faulthandler.enable()
 
-from quart import Quart, render_template, websocket, request, jsonify, send_file, redirect, Response
+from quart import Quart, render_template, websocket, request, jsonify, redirect, Response
 import asyncio
 import cv2
 from camera_worker import CameraWorker

--- a/src/packages/notification/telegram_notify/__init__.py
+++ b/src/packages/notification/telegram_notify/__init__.py
@@ -1,1 +1,3 @@
-from .telegram_notify import TelegramNotify
+from .telegram_notify import TelegramNotify as TelegramNotify
+
+__all__ = ["TelegramNotify"]

--- a/tests/test_camera_worker_read_timeout.py
+++ b/tests/test_camera_worker_read_timeout.py
@@ -2,7 +2,7 @@ import asyncio
 from queue import Queue
 
 def test_camera_worker_read_returns_none_on_timeout():
-    import sys, importlib
+    import sys
     import camera_worker
 
     worker = camera_worker.CameraWorker.__new__(camera_worker.CameraWorker)

--- a/tests/test_rapid_ocr_cleanup.py
+++ b/tests/test_rapid_ocr_cleanup.py
@@ -1,4 +1,3 @@
-import logging
 from tests.stubs import stub_cv2
 
 stub_cv2()


### PR DESCRIPTION
## Summary
- remove unused imports from app and tests
- define TelegramNotify re-export cleanly

## Testing
- `ruff check app.py src/packages/notification/telegram_notify/__init__.py tests/test_camera_worker_read_timeout.py tests/test_rapid_ocr_cleanup.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c82ef89794832bbc4361a2722003cf