### PR TITLE
Filter ROI overlays by selected group

### DIFF
--- a/app.py
+++ b/app.py
@@ -685,6 +685,11 @@ async def run_inference_loop(cam_id: str):
         for i, r in enumerate(rois):
             if np is None or r.get('type') != 'roi':
                 continue
+            should_show = forced_group == 'all' or (
+                output and r.get('group') == output
+            )
+            if not should_show:
+                continue
             pts = r.get('points', [])
             if len(pts) != 4:
                 continue


### PR DESCRIPTION
## Summary
- only draw ROI outlines when they match the forced group or the most recent inference output

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68c92e2c43c8832b8e8787b13f807d27