### PR TITLE
Show aggregated ROI payloads on inference UI

### DIFF
--- a/templates/partials/inference_content.html
+++ b/templates/partials/inference_content.html
@@ -158,6 +158,29 @@
             roiGrid.appendChild(item);
         }
 
+        function applyRoiResult(result, fallbackFrameTime) {
+            if (!result) return;
+            const roiId = result.id;
+            if (roiId === undefined || roiId === null) return;
+            ensureRoiItem(roiId);
+            const imgEl = document.getElementById(`${cellId}-roi-${roiId}`);
+            if (imgEl && Object.prototype.hasOwnProperty.call(result, 'image')) {
+                imgEl.src = result.image ? `data:image/jpeg;base64,${result.image}` : '';
+            }
+            const textEl = document.getElementById(`${cellId}-text-${roiId}`);
+            if (textEl) {
+                const text = result.text ?? '';
+                textEl.textContent = `OCR: ${text}`;
+            }
+            const timeEl = document.getElementById(`${cellId}-time-${roiId}`);
+            if (timeEl) {
+                const ts = typeof result.frame_time === 'number'
+                    ? result.frame_time
+                    : fallbackFrameTime;
+                timeEl.textContent = ts ? `เวลา: ${formatTs(ts)}` : '';
+            }
+        }
+
         function startLogUpdates(sourceName){
             currentLogSource = sourceName;
             stopLogUpdates();
@@ -276,6 +299,11 @@
 
                     : []);
             roiGrid.innerHTML = '';
+            rois.forEach(r => {
+                if (r && r.id !== undefined && r.id !== null) {
+                    ensureRoiItem(r.id);
+                }
+            });
 
             let startData;
             let startRes;
@@ -362,22 +390,15 @@
             roiSocket.onmessage = function(event) {
                 try {
                     const data = JSON.parse(event.data);
-                    if (Object.prototype.hasOwnProperty.call(data, 'id')) {
+                    if (Array.isArray(data.results)) {
+                        const fallbackFrameTime =
+                            typeof data.frame_time === 'number' ? data.frame_time : undefined;
                         setTimeout(() => {
-                            ensureRoiItem(data.id);
-                            const imgEl = document.getElementById(`${cellId}-roi-${data.id}`);
-                            if (imgEl) {
-                                imgEl.src = `data:image/jpeg;base64,${data.image}`;
-                            }
-                            const textEl = document.getElementById(`${cellId}-text-${data.id}`);
-                            if (textEl) {
-                                textEl.textContent = `OCR: ${data.text || ''}`;
-                            }
-                            const timeEl = document.getElementById(`${cellId}-time-${data.id}`);
-                            if (timeEl) {
-                                const frameTs = formatTs(data.frame_time);
-                                timeEl.textContent = `เวลา: ${frameTs}`;
-                            }
+                            data.results.forEach(item => applyRoiResult(item, fallbackFrameTime));
+                        }, 0);
+                    } else if (Object.prototype.hasOwnProperty.call(data, 'id')) {
+                        setTimeout(() => {
+                            applyRoiResult(data);
                         }, 0);
                     }
                 } catch (e) {
@@ -418,6 +439,11 @@
                 });
                 if (rois.length > 0) {
                     roiGrid.innerHTML = '';
+                    rois.forEach(r => {
+                        if (r && r.id !== undefined && r.id !== null) {
+                            ensureRoiItem(r.id);
+                        }
+                    });
                     openRoiSocket();
                 }
                 startLogUpdates(cfg.name);

--- a/templates/partials/inference_page_content.html
+++ b/templates/partials/inference_page_content.html
@@ -174,6 +174,11 @@ function createController(cellId){
         rois=roiList.filter(r=>r.type==='roi');
         populateLogRoiSelect();
         roiGrid.innerHTML='';
+        rois.forEach(r=>{
+            if(r && r.id!==undefined && r.id!==null){
+                ensureRoiItem(r.id);
+            }
+        });
 
         scoreTableBody.innerHTML='';
 
@@ -250,22 +255,15 @@ function createController(cellId){
                             });
                         }
                     },0);
-                } else if (Object.prototype.hasOwnProperty.call(data, 'id')) {
+                } else if (Array.isArray(data.results)) {
+                    const fallbackFrameTime=
+                        typeof data.frame_time==='number'?data.frame_time:undefined;
                     setTimeout(()=>{
-                        ensureRoiItem(data.id);
-                        const imgEl = document.getElementById(`${cellId}-roi-${data.id}`);
-                        if (imgEl) {
-                            imgEl.src = `data:image/jpeg;base64,${data.image}`;
-                        }
-                        const textEl = document.getElementById(`${cellId}-text-${data.id}`);
-                        if (textEl) {
-                            textEl.textContent = `OCR: ${data.text || ''}`;
-                        }
-                        const timeEl=document.getElementById(`${cellId}-time-${data.id}`);
-                        if(timeEl){
-                            const frameTs=formatTs(data.frame_time);
-                            timeEl.textContent=`เวลา: ${frameTs}`;
-                        }
+                        data.results.forEach(item=>applyRoiResult(item,fallbackFrameTime));
+                    },0);
+                } else if (Object.prototype.hasOwnProperty.call(data,'id')) {
+                    setTimeout(()=>{
+                        applyRoiResult(data);
                     },0);
                 }
             }catch(e){}
@@ -294,6 +292,27 @@ function createController(cellId){
         item.appendChild(p);
         item.appendChild(t);
         roiGrid.appendChild(item);
+    }
+
+    function applyRoiResult(result,fallbackFrameTime){
+        if(!result)return;
+        const roiId=result.id;
+        if(roiId===undefined||roiId===null)return;
+        ensureRoiItem(roiId);
+        const imgEl=document.getElementById(`${cellId}-roi-${roiId}`);
+        if(imgEl && Object.prototype.hasOwnProperty.call(result,'image')){
+            imgEl.src=result.image?`data:image/jpeg;base64,${result.image}`:'';
+        }
+        const textEl=document.getElementById(`${cellId}-text-${roiId}`);
+        if(textEl){
+            const text=result.text??'';
+            textEl.textContent=`OCR: ${text}`;
+        }
+        const timeEl=document.getElementById(`${cellId}-time-${roiId}`);
+        if(timeEl){
+            const ts=typeof result.frame_time==='number'?result.frame_time:fallbackFrameTime;
+            timeEl.textContent=ts?`เวลา: ${formatTs(ts)}`:'';
+        }
     }
 
     function startLogUpdates(sourceName){
@@ -377,6 +396,11 @@ function createController(cellId){
                     rois=(roiData.rois||[]).filter(r=>r.type==='roi');
                     populateLogRoiSelect();
                     roiGrid.innerHTML='';
+                    rois.forEach(r=>{
+                        if(r && r.id!==undefined && r.id!==null){
+                            ensureRoiItem(r.id);
+                        }
+                    });
                     startLogUpdates(cfg.name);
                 }
                 setRunningUI();


### PR DESCRIPTION
## Summary
- ensure ROI inference callbacks always create result entries so aggregated payloads are flushed per frame
- update both inference dashboards to pre-create ROI cards and handle aggregated ROI result batches for simultaneous display

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68c980725744832b9b1a813ca7548e01