### PR TITLE
Ensure aggregated ROI loggers use per-source handlers

### DIFF
--- a/src/utils/logger.py
+++ b/src/utils/logger.py
@@ -45,7 +45,12 @@ def get_logger(module_name: str, source: str | None = None) -> logging.Logger:
         logger = _loggers.get(key)
         if logger is not None:
             return logger
-        logger = logging.getLogger(module_name)
+        logger_name = module_name if not src else f"{module_name}:{src}"
+        logger = logging.getLogger(logger_name)
+        if logger.handlers:
+            for existing in list(logger.handlers):
+                logger.removeHandler(existing)
+                existing.close()
         logger.setLevel(logging.INFO)
         if src:
             log_dir = _DATA_SOURCES_ROOT / src


### PR DESCRIPTION
## Summary
- assign unique logger names per module and source to avoid handler reuse
- clean up any pre-existing handlers when configuring new loggers
- add a regression test ensuring aggregated ROI logs go to separate source files

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68ca3ff98ea8832b98fe6a50c613f33f