### PR TITLE
Clear status text after ROI load

### DIFF
--- a/templates/partials/inference_content.html
+++ b/templates/partials/inference_content.html
@@ -317,7 +317,7 @@
             }
             const res = await fetchWithStatus(`/load_roi_file?path=${encodeURIComponent(roiPath)}`);
             const data = await res.json();
-            statusEl.innerText = 'Loaded: ' + data.filename;
+            statusEl.innerText = '';
             allRois = data.rois || [];
             const roiList = allRois.filter(r => (r.type ?? 'roi') === 'roi');
             if (selectedGroup) {


### PR DESCRIPTION
## Summary
- clear the inference status text after loading ROI data so it does not overlay the video stream

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ca54fd7478832bbd30f2705c63034b