### PR TITLE
Adjust websocket scheme detection

### DIFF
--- a/templates/partials/inference_content.html
+++ b/templates/partials/inference_content.html
@@ -409,7 +409,9 @@
         }
 
         function openSocket() {
-            socket = new WebSocket(`ws://${location.host}/ws/${cam}`);
+            const wsScheme = location.protocol === 'https:' ? 'wss' : 'ws';
+            const wsBase = `${wsScheme}://${location.host}`;
+            socket = new WebSocket(`${wsBase}/ws/${cam}`);
             socket.binaryType = 'blob';
             socket.onmessage = async function(event) {
                 try {
@@ -430,7 +432,9 @@
         }
 
         function openRoiSocket() {
-            roiSocket = new WebSocket(`ws://${location.host}/ws_roi_result/${cam}`);
+            const wsScheme = location.protocol === 'https:' ? 'wss' : 'ws';
+            const wsBase = `${wsScheme}://${location.host}`;
+            roiSocket = new WebSocket(`${wsBase}/ws_roi_result/${cam}`);
             roiSocket.onmessage = function(event) {
                 try {
                     const data = JSON.parse(event.data);

--- a/templates/partials/inference_page_content.html
+++ b/templates/partials/inference_page_content.html
@@ -220,7 +220,9 @@ function createController(cellId){
 
 
     function openSocket(){
-        socket=new WebSocket(`ws://${location.host}/ws/${cam}`);
+        const wsScheme=location.protocol==='https:'?'wss':'ws';
+        const wsBase=`${wsScheme}://${location.host}`;
+        socket=new WebSocket(`${wsBase}/ws/${cam}`);
         socket.binaryType='blob';
         socket.onmessage=async event=>{
             const bitmap=await createImageBitmap(event.data);
@@ -234,7 +236,9 @@ function createController(cellId){
     }
 
     function openRoiSocket(){
-        roiSocket=new WebSocket(`ws://${location.host}/ws_roi_result/${cam}`);
+        const wsScheme=location.protocol==='https:'?'wss':'ws';
+        const wsBase=`${wsScheme}://${location.host}`;
+        roiSocket=new WebSocket(`${wsBase}/ws_roi_result/${cam}`);
         roiSocket.onmessage=event=>{
             try{
                 const data=JSON.parse(event.data);


### PR DESCRIPTION
## Summary
- update inference content WebSocket helpers to derive the ws or wss scheme from the current protocol
- apply the same dynamic WebSocket base logic to the inference page partial

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68ca573727d8832b9ab8ce2646cd26bd