### PR TITLE
Ensure inference start uses resolved group selection

### DIFF
--- a/templates/partials/inference_content.html
+++ b/templates/partials/inference_content.html
@@ -359,7 +359,7 @@
                 startRes = await fetch(`/start_inference/${cam}`, {
                     method: 'POST',
                     headers: {'Content-Type': 'application/json'},
-                    body: JSON.stringify({ ...camCfg, rois, group: selectedGroup, interval })
+                    body: JSON.stringify({ ...camCfg, rois, group: groupToUse, interval })
                 });
                 startData = await startRes.json().catch(() => ({}));
             } catch (err) {


### PR DESCRIPTION
## Summary
- send the resolved group selection when starting inference so the backend always sees the actual group or "all"

## Testing
- not run (front-end change)

------
https://chatgpt.com/codex/tasks/task_e_68ca5e1b6388832b85490f8029d996be