### PR TITLE
Reopen ROI sockets when resuming inference view

### DIFF
--- a/templates/partials/inference_content.html
+++ b/templates/partials/inference_content.html
@@ -512,9 +512,26 @@
                 const roiData = await roiRes.json();
                 allRois = roiData.rois || [];
                 const roiList = allRois.filter(r => (r.type ?? 'roi') === 'roi');
-                loadGroupOptions(roiList);
-                rois = [];
+                const activeGroup = loadGroupOptions(roiList);
+                const groupToUse = activeGroup || '';
+                if (groupToUse === 'all') {
+                    rois = roiList;
+                } else if (groupToUse) {
+                    rois = roiList.filter(r => (r.group ?? r.page ?? r.name) === groupToUse);
+                } else {
+                    rois = [];
+                }
                 roiGrid.innerHTML = '';
+                rois.forEach(r => {
+                    if (r && r.id !== undefined && r.id !== null) {
+                        ensureRoiItem(r.id);
+                    }
+                });
+                if (roiSocket) {
+                    roiSocket.close();
+                    roiSocket = null;
+                }
+                openRoiSocket();
                 stopLogUpdates();
                 startLogUpdates(cfg.name);
                 setRunningUI();


### PR DESCRIPTION
## Summary
- rebuild the ROI list in `checkStatus` based on the saved group selection
- reopen the ROI WebSocket when resuming a running inference session

## Testing
- not run (UI flow requires manual verification)


------
https://chatgpt.com/codex/tasks/task_e_68ca7f976a6c832b9c93033b105e6054