### PR TITLE
Allow ROI updates when group data received

### DIFF
--- a/templates/partials/inference_page_content.html
+++ b/templates/partials/inference_page_content.html
@@ -259,13 +259,15 @@ function createController(cellId){
                             });
                         }
                     },0);
-                } else if (Array.isArray(data.results)) {
+                }
+                if(Array.isArray(data.results)){
                     const fallbackFrameTime=
                         typeof data.frame_time==='number'?data.frame_time:undefined;
                     setTimeout(()=>{
                         data.results.forEach(item=>applyRoiResult(item,fallbackFrameTime));
                     },0);
-                } else if (Object.prototype.hasOwnProperty.call(data,'id')) {
+                }
+                if(Object.prototype.hasOwnProperty.call(data,'id')){
                     setTimeout(()=>{
                         applyRoiResult(data);
                     },0);


### PR DESCRIPTION
## Summary
- update the ROI websocket handler so page metadata updates do not block ROI rendering
- ensure ROI result messages are processed even when group data is present in the same payload

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68ca878be130832ba1da185da16bd38e