### PR TITLE
ปรับหน้า inference page แสดงเวลา OCR ต่อ ROI

### DIFF
--- a/templates/partials/inference_page_content.html
+++ b/templates/partials/inference_page_content.html
@@ -87,6 +87,17 @@ function createController(cellId){
         return `${d.toLocaleTimeString('th-TH',{hour12:false})}.${ms}`;
     };
 
+    const formatDuration=seconds=>{
+        if(!Number.isFinite(seconds)||seconds<0)return '';
+        if(seconds>=1){
+            return `${seconds.toFixed(2)} s`;
+        }
+        if(seconds>=0.001){
+            return `${Math.round(seconds*1000)} ms`;
+        }
+        return `${(seconds*1000).toFixed(2)} ms`;
+    };
+
     startButton.onclick=startStream;
     stopButton.onclick=stopStream;
     sourceSelect.onchange=()=>{
@@ -333,8 +344,14 @@ function createController(cellId){
         }
         const timeEl=document.getElementById(getRoiTimeId(key));
         if(timeEl){
-            const ts=typeof result.frame_time==='number'?result.frame_time:fallbackFrameTime;
-            timeEl.textContent=ts?`เวลา: ${formatTs(ts)}`:'';
+            const duration=typeof result.duration==='number'?result.duration:Number.NaN;
+            const durationText=formatDuration(duration);
+            if(durationText){
+                timeEl.textContent=`เวลา: ${durationText}`;
+            }else{
+                const ts=typeof result.frame_time==='number'?result.frame_time:fallbackFrameTime;
+                timeEl.textContent=ts?`เวลา: ${formatTs(ts)}`:'';
+            }
         }
     }
 
@@ -372,6 +389,10 @@ function createController(cellId){
                                 parts.push(`roi_id=${roiId}`);
                                 if(res.name)parts.push(`name=${res.name}`);
                                 if(groupLabel)parts.push(`group=${groupLabel}`);
+                                if(typeof res.duration==='number'){
+                                    const dur=formatDuration(res.duration);
+                                    if(dur)parts.push(`duration=${dur}`);
+                                }
                                 const textValue=typeof res.text==='string'?res.text:'';
                                 parts.push(`text=${textValue}`);
                                 td.textContent=parts.join(' | ');


### PR DESCRIPTION
## Summary
- เพิ่มการคำนวณและแสดงผลเวลา OCR ต่อ ROI บนหน้า inference page
- ปรับตาราง log ให้แสดงค่า duration สำหรับแต่ละ ROI

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ca88ea287c832b9be99b63626b14b6