### PR TITLE
Show ROI cards only when results are received

### DIFF
--- a/templates/partials/inference_page_content.html
+++ b/templates/partials/inference_page_content.html
@@ -185,11 +185,6 @@ function createController(cellId){
         rois=roiList.filter(r=>r.type==='roi');
         populateLogRoiSelect();
         roiGrid.innerHTML='';
-        rois.forEach(r=>{
-            if(r && r.id!==undefined && r.id!==null){
-                ensureRoiItem(r.id);
-            }
-        });
 
         scoreTableBody.innerHTML='';
 


### PR DESCRIPTION
## Summary
- update the inference page ROI grid to start empty when a stream launches
- rely on incoming ROI result events to create ROI cards so only active outputs are displayed

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68ca8b30842c832bbd07169a308cff4d