### PR TITLE
Show inference module names in ROI logs and cards

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -95,6 +95,13 @@ main {
   border: 2px solid red;
 }
 
+.roi-module {
+  margin: 4px 0 0;
+  font-size: 11px;
+  text-align: center;
+  color: #6c757d;
+}
+
 .roi-text {
   margin: 2px 0 0;
   font-size: 12px;

--- a/templates/partials/inference_content.html
+++ b/templates/partials/inference_content.html
@@ -155,9 +155,31 @@
             }
         }
 
+        const getModuleElementId = id => `${cellId}-module-${id}`;
+
+        function findRoiDataById(id) {
+            const key = String(id);
+            const match = rois.find(r => String(r?.id) === key);
+            if (match) return match;
+            return allRois.find(r => String(r?.id) === key) || null;
+        }
+
+        function normalizeModule(value) {
+            return typeof value === 'string' ? value.trim() : '';
+        }
+
+        function updateRoiModuleLabel(id, override = '') {
+            const moduleEl = document.getElementById(getModuleElementId(id));
+            if (!moduleEl) return;
+            const overrideText = normalizeModule(override);
+            const fallback = normalizeModule(findRoiDataById(id)?.module ?? '');
+            const moduleName = overrideText || fallback;
+            moduleEl.textContent = moduleName ? `โมดูล: ${moduleName}` : 'โมดูล: -';
+        }
+
         function ensureRoiItem(id) {
             if (document.getElementById(`${cellId}-roi-${id}`)) return;
-            const r = rois.find(r => r.id === id) || { id };
+            const r = findRoiDataById(id) || { id };
             const item = document.createElement('div');
             item.className = 'roi-item';
             const title = document.createElement('h4');
@@ -166,6 +188,9 @@
             const img = document.createElement('img');
             img.id = `${cellId}-roi-${id}`;
             img.className = 'roi-image';
+            const moduleLine = document.createElement('p');
+            moduleLine.id = getModuleElementId(id);
+            moduleLine.className = 'roi-module';
             const p = document.createElement('p');
             p.id = `${cellId}-text-${id}`;
             p.className = 'roi-text';
@@ -174,9 +199,11 @@
             t.className = 'roi-time';
             item.appendChild(title);
             item.appendChild(img);
+            item.appendChild(moduleLine);
             item.appendChild(p);
             item.appendChild(t);
             roiGrid.appendChild(item);
+            updateRoiModuleLabel(id);
         }
 
         function applyRoiResult(result, fallbackFrameTime) {
@@ -184,6 +211,7 @@
             const roiId = result.id;
             if (roiId === undefined || roiId === null) return;
             ensureRoiItem(roiId);
+            updateRoiModuleLabel(roiId, result.module);
             const imgEl = document.getElementById(`${cellId}-roi-${roiId}`);
             if (imgEl && Object.prototype.hasOwnProperty.call(result, 'image')) {
                 imgEl.src = result.image ? `data:image/jpeg;base64,${result.image}` : '';
@@ -244,6 +272,8 @@
                                     if(resultTs)parts.push(`result=${formatTs(resultTs)}`);
                                     parts.push(`roi_id=${roiId}`);
                                     if(res.name)parts.push(`name=${res.name}`);
+                                    const moduleName=typeof res.module==='string'?res.module.trim():'';
+                                    if(moduleName)parts.push(`module=${moduleName}`);
                                     if(groupLabel)parts.push(`group=${groupLabel}`);
                                     if(typeof res.duration==='number'){
                                         const dur=formatDuration(res.duration);
@@ -377,6 +407,7 @@
             rois.forEach(r => {
                 if (r && r.id !== undefined && r.id !== null) {
                     ensureRoiItem(r.id);
+                    updateRoiModuleLabel(r.id);
                 }
             });
 
@@ -525,6 +556,7 @@
                 rois.forEach(r => {
                     if (r && r.id !== undefined && r.id !== null) {
                         ensureRoiItem(r.id);
+                        updateRoiModuleLabel(r.id);
                     }
                 });
                 if (roiSocket) {

--- a/templates/partials/inference_page_content.html
+++ b/templates/partials/inference_page_content.html
@@ -185,6 +185,12 @@ function createController(cellId){
         rois=roiList.filter(r=>r.type==='roi');
         populateLogRoiSelect();
         roiGrid.innerHTML='';
+        rois.forEach(r=>{
+            if(r && r.id!==undefined && r.id!==null){
+                ensureRoiItem(r.id);
+                updateRoiModuleLabel(r.id);
+            }
+        });
 
         scoreTableBody.innerHTML='';
 
@@ -285,11 +291,30 @@ function createController(cellId){
     const getRoiElementId=id=>`${cellId}-roi-${id}`;
     const getRoiTextId=id=>`${cellId}-text-${id}`;
     const getRoiTimeId=id=>`${cellId}-time-${id}`;
+    const getRoiModuleId=id=>`${cellId}-module-${id}`;
+
+    function findRoiDataById(id){
+        const key=String(id);
+        return rois.find(r=>String(r?.id)===key)||null;
+    }
+
+    function normalizeModule(value){
+        return typeof value==='string'?value.trim():'';
+    }
+
+    function updateRoiModuleLabel(id,override=''){
+        const moduleEl=document.getElementById(getRoiModuleId(id));
+        if(!moduleEl)return;
+        const overrideText=normalizeModule(override);
+        const fallback=normalizeModule(findRoiDataById(id)?.module??'');
+        const moduleName=overrideText||fallback;
+        moduleEl.textContent=moduleName?`โมดูล: ${moduleName}`:'โมดูล: -';
+    }
 
     function ensureRoiItem(id){
         const key=String(id);
         if(document.getElementById(getRoiElementId(key)))return;
-        const r=rois.find(r=>String(r.id)===key)||{id:key};
+        const r=findRoiDataById(key)||{id:key};
         const item=document.createElement('div');
         item.className='roi-item';
         const title=document.createElement('h4');
@@ -300,6 +325,9 @@ function createController(cellId){
         img.className='roi-image';
         img.alt=`ROI ${key}`;
         img.loading='lazy';
+        const moduleLine=document.createElement('p');
+        moduleLine.id=getRoiModuleId(key);
+        moduleLine.className='roi-module';
         const p=document.createElement('p');
         p.id=getRoiTextId(key);
         p.className='roi-text';
@@ -308,9 +336,11 @@ function createController(cellId){
         t.className='roi-time';
         item.appendChild(title);
         item.appendChild(img);
+        item.appendChild(moduleLine);
         item.appendChild(p);
         item.appendChild(t);
         roiGrid.appendChild(item);
+        updateRoiModuleLabel(key);
     }
 
     function applyRoiResult(result,fallbackFrameTime){
@@ -319,6 +349,7 @@ function createController(cellId){
         if(roiId===undefined||roiId===null)return;
         const key=String(roiId);
         ensureRoiItem(key);
+        updateRoiModuleLabel(key,result.module);
         const imgEl=document.getElementById(getRoiElementId(key));
         if(imgEl && Object.prototype.hasOwnProperty.call(result,'image')){
             const imgData=result.image;
@@ -383,6 +414,8 @@ function createController(cellId){
                                 if(resultTs)parts.push(`result=${formatTs(resultTs)}`);
                                 parts.push(`roi_id=${roiId}`);
                                 if(res.name)parts.push(`name=${res.name}`);
+                                const moduleName=typeof res.module==='string'?res.module.trim():'';
+                                if(moduleName)parts.push(`module=${moduleName}`);
                                 if(groupLabel)parts.push(`group=${groupLabel}`);
                                 if(typeof res.duration==='number'){
                                     const dur=formatDuration(res.duration);
@@ -472,6 +505,7 @@ function createController(cellId){
                     rois.forEach(r=>{
                         if(r && r.id!==undefined && r.id!==null){
                             ensureRoiItem(r.id);
+                            updateRoiModuleLabel(r.id);
                         }
                     });
                     startLogUpdates(cfg.name);


### PR DESCRIPTION
## Summary
- display the configured inference module beneath each ROI thumbnail on the inference group and page views
- include module names in the parsed AGGREGATED_ROI log entries shown in both inference views
- add styling for the new module label in the ROI list

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cacb311e70832ba6836cf92ecb81e2