### PR TITLE
Preserve active source when camera settings omit name

### DIFF
--- a/app.py
+++ b/app.py
@@ -1135,7 +1135,11 @@ async def ws_roi_result(cam_id: str):
 # =========================
 async def apply_camera_settings(cam_id: str, data: dict) -> bool:
     async with get_cam_lock(cam_id):
-        active_sources[cam_id] = data.get("name", "")
+        name_val = data.get("name")
+        if isinstance(name_val, str) and name_val:
+            active_sources[cam_id] = name_val
+        elif cam_id not in active_sources:
+            active_sources[cam_id] = ""
         source_val = data.get("source", "")
         width_val = data.get("width")
         height_val = data.get("height")

--- a/tests/test_z_apply_camera_settings.py
+++ b/tests/test_z_apply_camera_settings.py
@@ -1,0 +1,46 @@
+import asyncio
+import importlib
+import sys
+from pathlib import Path
+
+
+def test_apply_camera_settings_preserves_existing_active_source():
+    original_cv2 = sys.modules.get("cv2")
+    original_quart = sys.modules.get("quart")
+
+    app = importlib.import_module("app")
+
+    async def run():
+        cam_id = "preserve_cam"
+        app.active_sources[cam_id] = "saved-source"
+        try:
+            result = await app.apply_camera_settings(
+                cam_id,
+                {
+                    "source": "0",
+                    "stream_type": "opencv",
+                },
+            )
+            preserved = app.active_sources.get(cam_id)
+        finally:
+            app.camera_sources.pop(cam_id, None)
+            app.camera_resolutions.pop(cam_id, None)
+            app.camera_backends.pop(cam_id, None)
+            app.active_sources.pop(cam_id, None)
+            Path(app.STATE_FILE).unlink(missing_ok=True)
+        assert result is True
+        assert preserved == "saved-source"
+
+    try:
+        asyncio.run(run())
+    finally:
+        sys.modules.pop("app", None)
+        sys.modules.pop("camera_worker", None)
+        if original_cv2 is not None:
+            sys.modules["cv2"] = original_cv2
+        else:
+            sys.modules.pop("cv2", None)
+        if original_quart is not None:
+            sys.modules["quart"] = original_quart
+        else:
+            sys.modules.pop("quart", None)


### PR DESCRIPTION
## Summary
- keep the previously selected active source when camera settings updates do not include a name
- add a regression test that exercises apply_camera_settings without a name and verifies the active source persists

## Testing
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68cb8b9f9184832b8b718c4ee45c3554