### PR TITLE
Add MQTT configuration UI and ROI MQTT publishing

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ dependencies = [
     "easyocr",
     "rapidocr",
     "pytesseract",
+    "paho-mqtt",
 ]
 
 [project.optional-dependencies]

--- a/templates/base.html
+++ b/templates/base.html
@@ -21,6 +21,7 @@
         <ul class="navbar-nav me-auto mb-2 mb-lg-0">
           <li class="nav-item"><a href="/home" class="nav-link" data-bs-toggle="tooltip" title="Home">🏠 Home</a></li>
           <li class="nav-item"><a href="/create_source" class="nav-link" data-bs-toggle="tooltip" title="Create Source">➕ Create Source</a></li>
+          <li class="nav-item"><a href="/create_mqtt" class="nav-link" data-bs-toggle="tooltip" title="MQTT Config">📡 MQTT</a></li>
           <li class="nav-item"><a href="/roi" class="nav-link" data-bs-toggle="tooltip" title="ROI">📐 ROI</a></li>
           <li class="nav-item"><a href="/inference" class="nav-link" data-bs-toggle="tooltip" title="Inference Group">🤖 Inference Group</a></li>
           <li class="nav-item"><a href="/inference_page" class="nav-link" data-bs-toggle="tooltip" title="Inference Page">📄 Inference Page</a></li>

--- a/templates/create_mqtt.html
+++ b/templates/create_mqtt.html
@@ -1,0 +1,218 @@
+{% extends "base.html" %}
+{% block title %}MQTT Config{% endblock %}
+{% block content %}
+<div class="container py-4">
+  <div class="card mb-4">
+    <div class="card-header">
+      <h2 class="mb-0">สร้างการเชื่อมต่อ MQTT</h2>
+    </div>
+    <div class="card-body">
+      <form id="mqtt-form" class="row g-3">
+        <div class="col-md-4">
+          <label class="form-label" for="name">ชื่อการตั้งค่า</label>
+          <input type="text" id="name" name="name" class="form-control" required>
+        </div>
+        <div class="col-md-4">
+          <label class="form-label" for="host">MQTT Host</label>
+          <input type="text" id="host" name="host" class="form-control" required>
+        </div>
+        <div class="col-md-4">
+          <label class="form-label" for="port">Port</label>
+          <input type="number" id="port" name="port" class="form-control" min="1" max="65535" value="1883">
+        </div>
+        <div class="col-md-4">
+          <label class="form-label" for="username">Username</label>
+          <input type="text" id="username" name="username" class="form-control" autocomplete="off">
+        </div>
+        <div class="col-md-4">
+          <label class="form-label" for="password">Password</label>
+          <input type="password" id="password" name="password" class="form-control" autocomplete="new-password">
+        </div>
+        <div class="col-md-4">
+          <label class="form-label" for="client_id">Client ID</label>
+          <input type="text" id="client_id" name="client_id" class="form-control" autocomplete="off">
+        </div>
+        <div class="col-md-6">
+          <label class="form-label" for="base_topic">Base Topic (เช่น office/floor1)</label>
+          <input type="text" id="base_topic" name="base_topic" class="form-control" autocomplete="off">
+        </div>
+        <div class="col-md-6">
+          <label class="form-label" for="keepalive">Keepalive (วินาที)</label>
+          <input type="number" id="keepalive" name="keepalive" class="form-control" min="1" value="60">
+        </div>
+        <div class="col-md-4">
+          <label class="form-label" for="qos">QoS</label>
+          <select id="qos" name="qos" class="form-select">
+            <option value="0" selected>0 - At most once</option>
+            <option value="1">1 - At least once</option>
+            <option value="2">2 - Exactly once</option>
+          </select>
+        </div>
+        <div class="col-md-4">
+          <label class="form-label" for="publish_timeout">Timeout การส่ง (วินาที)</label>
+          <input type="number" step="0.1" min="0.1" id="publish_timeout" name="publish_timeout" class="form-control" value="5">
+        </div>
+        <div class="col-md-4 d-flex align-items-center">
+          <div class="form-check me-3">
+            <input class="form-check-input" type="checkbox" id="retain" name="retain">
+            <label class="form-check-label" for="retain">Retain</label>
+          </div>
+          <div class="form-check">
+            <input class="form-check-input" type="checkbox" id="tls" name="tls">
+            <label class="form-check-label" for="tls">ใช้ TLS</label>
+          </div>
+        </div>
+        <div class="col-12">
+          <button type="submit" class="btn btn-primary">บันทึกการตั้งค่า</button>
+        </div>
+      </form>
+    </div>
+  </div>
+
+  <div class="card">
+    <div class="card-header d-flex justify-content-between align-items-center">
+      <h3 class="mb-0">รายการ MQTT Config</h3>
+      <button type="button" class="btn btn-outline-secondary btn-sm" id="refresh-btn">รีเฟรช</button>
+    </div>
+    <div class="card-body">
+      <div class="table-responsive">
+        <table class="table table-hover align-middle">
+          <thead class="table-light">
+            <tr>
+              <th>ชื่อ</th>
+              <th>Host</th>
+              <th>Port</th>
+              <th>Username</th>
+              <th>Base Topic</th>
+              <th>QoS</th>
+              <th>Retain</th>
+              <th>TLS</th>
+              <th>Keepalive</th>
+              <th>Timeout</th>
+              <th>Actions</th>
+            </tr>
+          </thead>
+          <tbody id="mqtt-table-body"></tbody>
+        </table>
+      </div>
+    </div>
+  </div>
+</div>
+
+<script>
+(async function() {
+  const form = document.getElementById('mqtt-form');
+  const tableBody = document.getElementById('mqtt-table-body');
+  const refreshBtn = document.getElementById('refresh-btn');
+
+  function parseNumber(value, fallback) {
+    if (value === undefined || value === null || value === '') return fallback;
+    const parsed = Number(value);
+    return Number.isFinite(parsed) ? parsed : fallback;
+  }
+
+  async function loadConfigs() {
+    try {
+      const res = await fetch('/mqtt_configs');
+      if (!res.ok) throw new Error('bad response');
+      const data = await res.json();
+      tableBody.innerHTML = '';
+      if (!Array.isArray(data) || data.length === 0) {
+        const row = document.createElement('tr');
+        const cell = document.createElement('td');
+        cell.colSpan = 11;
+        cell.className = 'text-center text-muted';
+        cell.textContent = 'ยังไม่มีการตั้งค่า MQTT';
+        row.appendChild(cell);
+        tableBody.appendChild(row);
+        return;
+      }
+      data.forEach(cfg => {
+        const row = document.createElement('tr');
+        row.innerHTML = `
+          <td>${cfg.name}</td>
+          <td>${cfg.host}</td>
+          <td>${cfg.port ?? ''}</td>
+          <td>${cfg.username || '-'}</td>
+          <td>${cfg.base_topic || '-'}</td>
+          <td>${cfg.qos ?? 0}</td>
+          <td>${cfg.retain ? 'Yes' : 'No'}</td>
+          <td>${cfg.tls ? 'Yes' : 'No'}</td>
+          <td>${cfg.keepalive ?? '-'}</td>
+          <td>${cfg.publish_timeout ?? '-'}</td>
+          <td></td>`;
+        const actionCell = row.lastElementChild;
+        const delBtn = document.createElement('button');
+        delBtn.className = 'btn btn-danger btn-sm';
+        delBtn.textContent = 'ลบ';
+        delBtn.addEventListener('click', async () => {
+          if (!confirm(`ลบการตั้งค่า ${cfg.name}?`)) return;
+          try {
+            const resp = await fetch(`/mqtt_configs/${encodeURIComponent(cfg.name)}`, {
+              method: 'DELETE'
+            });
+            const result = await resp.json();
+            if (!resp.ok) throw new Error(result.message || 'delete failed');
+            showAlert('ลบการตั้งค่าแล้ว', 'success');
+            await loadConfigs();
+          } catch (err) {
+            console.error(err);
+            showAlert('ลบการตั้งค่าไม่สำเร็จ', 'error');
+          }
+        });
+        actionCell.appendChild(delBtn);
+        tableBody.appendChild(row);
+      });
+      showAlert('โหลดข้อมูล MQTT สำเร็จ', 'success');
+    } catch (err) {
+      console.error(err);
+      showAlert('โหลดข้อมูล MQTT ไม่สำเร็จ', 'error');
+    }
+  }
+
+  form.addEventListener('submit', async (e) => {
+    e.preventDefault();
+    const formData = new FormData(form);
+    const payload = {
+      name: formData.get('name')?.toString().trim(),
+      host: formData.get('host')?.toString().trim(),
+      port: parseNumber(formData.get('port'), 1883),
+      username: formData.get('username')?.toString().trim() || '',
+      password: formData.get('password')?.toString() || '',
+      client_id: formData.get('client_id')?.toString().trim() || '',
+      base_topic: formData.get('base_topic')?.toString().trim() || '',
+      qos: parseNumber(formData.get('qos'), 0),
+      retain: document.getElementById('retain').checked,
+      tls: document.getElementById('tls').checked,
+      keepalive: parseNumber(formData.get('keepalive'), 60),
+      publish_timeout: parseNumber(formData.get('publish_timeout'), 5),
+    };
+
+    try {
+      const res = await fetch('/mqtt_configs', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(payload),
+      });
+      const data = await res.json();
+      if (!res.ok) {
+        showAlert(data.message || 'บันทึกไม่สำเร็จ', 'error');
+        return;
+      }
+      showAlert('บันทึกการตั้งค่าเรียบร้อย', 'success');
+      form.reset();
+      document.getElementById('port').value = '1883';
+      document.getElementById('keepalive').value = '60';
+      document.getElementById('publish_timeout').value = '5';
+      await loadConfigs();
+    } catch (err) {
+      console.error(err);
+      showAlert('บันทึกไม่สำเร็จ', 'error');
+    }
+  });
+
+  refreshBtn.addEventListener('click', loadConfigs);
+  await loadConfigs();
+})();
+</script>
+{% endblock %}

--- a/templates/roi_selection.html
+++ b/templates/roi_selection.html
@@ -42,6 +42,7 @@
         let currentSource = "";
         let groups = [];
         let modules = [];
+        let mqttConfigs = [];
         let initialized = false;
         let isStreaming = false;
         let hasStarted = false;
@@ -148,6 +149,19 @@
             } catch (err) {
                 console.error('Failed to load inference modules', err);
                 modules = [];
+            }
+            renderRoiList();
+        }
+
+        async function loadMqttConfigs() {
+            try {
+                const res = await fetch('/mqtt_configs');
+                if (!res.ok) throw new Error('Bad response');
+                const data = await res.json();
+                mqttConfigs = Array.isArray(data) ? data : [];
+            } catch (err) {
+                console.error('Failed to load MQTT configs', err);
+                mqttConfigs = [];
             }
             renderRoiList();
         }
@@ -275,6 +289,8 @@
                         id: roiId,
                         group: groupId,
                         module: "",
+                        name: '',
+                        mqtt_config: '',
                         points: currentPoints.slice(),
                         type: 'roi'
                     });
@@ -308,7 +324,7 @@
                         pageRois.push({ id: roiId, points, type: 'page', page: '', image: null });
 
                     } else {
-                        rois.push({ id: roiId, group: groupId, module: "", points, type: 'roi' });
+                        rois.push({ id: roiId, group: groupId, module: "", name: '', mqtt_config: '', points, type: 'roi' });
                     }
                     renderRoiList();
                     fetch('/save_roi', {
@@ -475,7 +491,7 @@
                 table.className = 'table table-hover table-sm';
                 const thead = document.createElement('thead');
                 const headerRow = document.createElement('tr');
-                ['ID', 'xywh', 'Group', 'Inference Module', 'Delete'].forEach(colName => {
+                ['ID', 'xywh', 'Group', 'Inference Module', 'MQTT', 'Delete'].forEach(colName => {
                     const th = document.createElement('th');
                     th.textContent = colName;
                     headerRow.appendChild(th);
@@ -527,6 +543,25 @@
                     select.addEventListener('change', e => updateRoiModule(idx, e.target.value));
                     tdModule.appendChild(select);
                     tr.appendChild(tdModule);
+
+                    const tdMqtt = document.createElement('td');
+                    const mqttSelect = document.createElement('select');
+                    mqttSelect.className = 'form-select form-select-sm';
+                    const noneOption = document.createElement('option');
+                    noneOption.value = '';
+                    noneOption.textContent = 'ไม่ส่ง';
+                    mqttSelect.appendChild(noneOption);
+                    mqttConfigs.forEach(cfg => {
+                        if (!cfg || !cfg.name) return;
+                        const opt = document.createElement('option');
+                        opt.value = cfg.name;
+                        opt.textContent = cfg.name;
+                        if ((r.mqtt_config ?? '') === cfg.name) opt.selected = true;
+                        mqttSelect.appendChild(opt);
+                    });
+                    mqttSelect.addEventListener('change', e => updateRoiMqtt(idx, e.target.value));
+                    tdMqtt.appendChild(mqttSelect);
+                    tr.appendChild(tdMqtt);
 
                     const tdDel = document.createElement('td');
                     const delBtn = document.createElement('button');
@@ -688,10 +723,13 @@
                             { x: r.x, y: r.y + r.height }
                         ];
                     }
+                    const mqttName = typeof r.mqtt_config === 'string' ? r.mqtt_config : '';
                     return {
                         id: r.id ?? String(idx + 1),
                         group: r.group ?? null,
                         module: r.module ?? "",
+                        name: r.name ?? '',
+                        mqtt_config: mqttName,
                         points: pts || [],
                         type: 'roi'
                     };
@@ -737,6 +775,15 @@
 
         function updateRoiModule(i, module) {
             rois[i].module = module;
+            fetch('/save_roi', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ rois: rois.concat(pageRois).concat(typeof otherRois !== 'undefined' ? otherRois : []), source: currentSource })
+            });
+        }
+
+        function updateRoiMqtt(i, mqttName) {
+            rois[i].mqtt_config = mqttName || '';
             fetch('/save_roi', {
                 method: 'POST',
                 headers: { 'Content-Type': 'application/json' },
@@ -850,6 +897,7 @@
         window.clearAllRois = clearAllRois;
         window.updateRoiGroup = updateRoiGroup;
         window.updateRoiModule = updateRoiModule;
+        window.updateRoiMqtt = updateRoiMqtt;
         window.updateRoiId = updateRoiId;
         window.deleteRoi = deleteRoi;
         window.updatePageRoiName = updatePageRoiName;
@@ -865,6 +913,7 @@
             await loadSources();
             await loadGroups();
             await loadModules();
+            await loadMqttConfigs();
             await checkStatus();
             if (typeof showAlert === 'function') showAlert('ROI selection ready', 'success');
         })();


### PR DESCRIPTION
## Summary
- add MQTT configuration management endpoints and publishing helper
- expose new create MQTT page with table and form
- allow ROI selection to assign MQTT configs and publish results automatically

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cc92b33498832ba1502378a6573975