### PR TITLE
Adjust inference group controls layout

### DIFF
--- a/templates/partials/inference_content.html
+++ b/templates/partials/inference_content.html
@@ -3,11 +3,13 @@
     <div class="video-col">
         <div class="card roi-card video-card">
             <div id="cam1" class="cam-cell">
-                <div class="d-flex align-items-center mb-2 gap-2 menu-select-list">
+                <div class="d-flex align-items-center mb-2 gap-2 menu-select-list flex-wrap">
                     <label for="cam1-sourceSelect" class="form-label mb-0">Source:</label>
                     <select id="cam1-sourceSelect" class="form-select w-auto"></select>
-                    <label for="cam1-intervalInput" class="form-label mb-0">Time:</label>
+                    <label for="cam1-intervalInput" class="form-label mb-0">Time (interval):</label>
                     <input id="cam1-intervalInput" type="number" class="form-control w-auto" min="0" step="0.1" value="1" />
+                    <label for="cam1-groupSelect" class="form-label mb-0">Group:</label>
+                    <select id="cam1-groupSelect" class="form-select w-auto flex-grow-1" style="min-width:0;"></select>
                 </div>
                 <button id="cam1-startButton" class="btn btn-primary me-2">Start</button>
                 <button id="cam1-stopButton" class="btn btn-danger" disabled>Stop</button>
@@ -31,10 +33,6 @@
         </div>
     </div>
     <div class="card roi-card roi-list-card">
-        <div class="d-flex align-items-center mb-2 gap-2 menu-select-list">
-            <label for="cam1-groupSelect" class="form-label mb-0">Group:</label>
-            <select id="cam1-groupSelect" class="form-select w-auto flex-grow-1" style="min-width:0;"></select>
-        </div>
         <div id="cam1-rois" class="roi-grid"></div>
     </div>
 </div>


### PR DESCRIPTION
## Summary
- move the group selector next to the source and time controls on the inference group stream card
- rename the time label to "Time (interval)" to clarify its purpose

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68ccba90ef84832baca332dace7a39ca