### PR TITLE
Switch TrOCR default to small printed model

### DIFF
--- a/inference_modules/trocr/custom.py
+++ b/inference_modules/trocr/custom.py
@@ -26,7 +26,7 @@ class TrOCROCR(BaseOCR):
 
     def __init__(self, model_name: str | None = None, device: str | None = None) -> None:
         super().__init__()
-        self.model_name = model_name or "microsoft/trocr-base-printed"
+        self.model_name = model_name or "microsoft/trocr-small-printed"
         self.device_override = device
         self._model_lock = threading.Lock()
         self._processor: Any = None


### PR DESCRIPTION
## Summary
- default the TrOCR inference module to the lighter `microsoft/trocr-small-printed` checkpoint for faster execution

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68ccdeef5358832ba68bc67e06ed76fd