### PR TITLE
Adjust ROI page card layout

### DIFF
--- a/templates/roi_selection.html
+++ b/templates/roi_selection.html
@@ -468,12 +468,12 @@
             container.innerHTML = '';
 
             const row = document.createElement('div');
-            row.className = 'row row-cols-1 row-cols-lg-2 g-3 align-items-stretch';
+            row.className = 'row g-3';
             container.appendChild(row);
 
             const createCard = (title) => {
                 const col = document.createElement('div');
-                col.className = 'col';
+                col.className = 'col-12';
 
                 const card = document.createElement('div');
                 card.className = 'card h-100';


### PR DESCRIPTION
## Summary
- update the ROI selection page layout to stack the Page ROI List card below the ROI List card while keeping equal widths

## Testing
- not run (UI change only)


------
https://chatgpt.com/codex/tasks/task_e_68cd87051564832b8c46173af1f25c20