### PR TITLE
Adjust ROI list spacing

### DIFF
--- a/templates/roi_selection.html
+++ b/templates/roi_selection.html
@@ -22,7 +22,7 @@
     </div>
 </div>
 
-<div id="roiList"></div>
+<div id="roiList" class="mt-4"></div>
 
 <script>
     (function() {


### PR DESCRIPTION
## Summary
- add Bootstrap top margin class to the ROI list container for clearer spacing below the toolbar

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cd8b9c2908832bbefd1cf02fa7e74e