### PR TITLE
Adjust inference layouts to use fluid shell

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -57,6 +57,14 @@ main.app-main {
   margin: 0 auto;
 }
 
+.app-shell--fluid {
+  max-width: min(100%, 1800px);
+  width: 100%;
+  margin: 0 auto;
+  padding-left: clamp(1rem, 2vw, 2.5rem);
+  padding-right: clamp(1rem, 2vw, 2.5rem);
+}
+
 @media (max-width: 992px) {
   main.app-main {
     padding: 6rem 1.25rem 3rem;

--- a/templates/base.html
+++ b/templates/base.html
@@ -70,7 +70,7 @@
   </nav>
   {% include 'partials/alert.html' %}
   <main id="content" class="app-main">
-    <div class="app-shell container-xxl">
+    <div class="{% block shell_classes %}app-shell container-xxl{% endblock %}">
       {% block content %}{% endblock %}
     </div>
   </main>

--- a/templates/inference.html
+++ b/templates/inference.html
@@ -1,6 +1,8 @@
 {% extends "base.html" %}
 {% block title %}Inference Group{% endblock %}
 
+{% block shell_classes %}app-shell app-shell--fluid{% endblock %}
+
 {% block content %}
 {% include 'partials/inference_content.html' %}
 {% endblock %}

--- a/templates/inference_page.html
+++ b/templates/inference_page.html
@@ -1,5 +1,6 @@
 {% extends "base.html" %}
 {% block title %}Inference Page{% endblock %}
+{% block shell_classes %}app-shell app-shell--fluid{% endblock %}
 {% block content %}
 {% include 'partials/inference_page_content.html' %}
 {% endblock %}


### PR DESCRIPTION
## Summary
- allow overriding the main shell container class from child templates
- apply a fluid layout to the inference group and inference page content
- add styling for the fluid shell to expand near full width with responsive padding

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cd91d6def4832b822723f6c8741ed1