### PR TITLE
Add padding to video wrapper for inference views

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -442,6 +442,7 @@ button.delete {
   border-radius: var(--radius-md);
   overflow: hidden;
   box-shadow: 0 25px 55px -35px rgba(15, 23, 42, 0.7);
+  padding: 10px;
 }
 
 #video {


### PR DESCRIPTION
## Summary
- add 10px padding to the shared video wrapper container to give extra spacing on inference group and page views

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cd97e21e4c832b8a35dca0dd3d7812