### PR TITLE
Improve select dropdown visual styling

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -270,10 +270,60 @@ button.delete {
   box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.15);
 }
 
+.form-select {
+  appearance: none;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  position: relative;
+  padding-right: 2.8rem;
+  background-image:
+    linear-gradient(135deg, rgba(148, 163, 184, 0.18), rgba(96, 165, 250, 0.18)),
+    url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='20' height='20' viewBox='0 0 20 20' fill='none'%3E%3Cpath d='M5.25 7.5L10 12.5L14.75 7.5' stroke='%233C4B76' stroke-width='1.6' stroke-linecap='round' stroke-linejoin='round'/%3E%3C/svg%3E");
+  background-position: 0 0, right 1rem center;
+  background-size: auto, 1.05rem;
+  background-repeat: no-repeat;
+  background-origin: border-box;
+  background-clip: padding-box, border-box;
+  cursor: pointer;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease, transform 0.2s ease;
+}
+
+.form-select:hover {
+  border-color: rgba(37, 99, 235, 0.45);
+  box-shadow: 0 10px 18px -24px rgba(37, 99, 235, 0.7);
+  transform: translateY(-1px);
+}
+
 .form-control:focus,
 .form-select:focus {
   border-color: rgba(37, 99, 235, 0.55);
   box-shadow: 0 0 0 0.18rem rgba(37, 99, 235, 0.15);
+}
+
+.form-select::after {
+  display: none;
+}
+
+.form-select:focus {
+  transform: translateY(-1px);
+}
+
+.form-select::placeholder {
+  color: rgba(100, 116, 139, 0.8);
+}
+
+.form-select-sm {
+  padding-right: 2.25rem;
+  background-position: 0 0, right 0.75rem center;
+  background-size: auto, 0.85rem;
+}
+
+.form-select:disabled {
+  cursor: not-allowed;
+  opacity: 0.7;
+  background-image:
+    linear-gradient(135deg, rgba(148, 163, 184, 0.18), rgba(96, 165, 250, 0.18)),
+    url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='20' height='20' viewBox='0 0 20 20' fill='none'%3E%3Cpath d='M5.25 7.5L10 12.5L14.75 7.5' stroke='%2394A3B8' stroke-width='1.6' stroke-linecap='round' stroke-linejoin='round'/%3E%3C/svg%3E");
 }
 
 .form-label {


### PR DESCRIPTION
## Summary
- enhance the global `.form-select` styling with a gradient background and embedded chevron icon so dropdowns look clickable
- add hover, focus, and disabled state feedback to make select inputs feel interactive and consistent across sizes

## Testing
- not run (UI-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68ce0ca4c8e0832bb08451ea8d0b5aef