### PR TITLE
Add striped styling to data tables

### DIFF
--- a/templates/create_mqtt.html
+++ b/templates/create_mqtt.html
@@ -76,7 +76,7 @@
     </div>
     <div class="card-body">
       <div class="table-responsive">
-        <table class="table table-hover align-middle">
+        <table class="table table-hover table-striped align-middle">
           <thead class="table-light">
             <tr>
               <th>ชื่อ</th>

--- a/templates/create_source.html
+++ b/templates/create_source.html
@@ -49,7 +49,7 @@
       <h3>รายการแหล่งสัญญาณ</h3>
     </div>
     <div class="card-body">
-      <table class="table table-hover mt-3">
+      <table class="table table-hover table-striped mt-3">
     <thead class="table-light">
       <tr>
         <th>ชื่อ</th>

--- a/templates/partials/inference_content.html
+++ b/templates/partials/inference_content.html
@@ -25,7 +25,7 @@
                 <select id="cam1-logRoiSelect" class="form-select w-auto"></select>
             </div>
             <div class="log-wrapper">
-                <table id="cam1-logTable" class="table">
+                <table id="cam1-logTable" class="table table-striped">
                     <thead><tr><th>Log</th></tr></thead>
                     <tbody id="cam1-logBody"></tbody>
                 </table>

--- a/templates/partials/inference_page_content.html
+++ b/templates/partials/inference_page_content.html
@@ -15,7 +15,7 @@
             <div class="video-wrapper">
                 <canvas id="cam1-video" class="stream-video"></canvas>
                 <p>page: <span id="cam1-pageName"></span></p>
-                <table id="cam1-pageScores" class="table">
+                <table id="cam1-pageScores" class="table table-striped">
                     <thead><tr><th>Page</th><th>Score</th></tr></thead>
                     <tbody id="cam1-pageScoresBody"></tbody>
                 </table>
@@ -28,7 +28,7 @@
                 <select id="cam1-logRoiSelect" class="form-select w-auto"></select>
             </div>
             <div class="log-wrapper">
-                <table id="cam1-logTable" class="table">
+                <table id="cam1-logTable" class="table table-striped">
                     <thead><tr><th>Log</th></tr></thead>
                     <tbody id="cam1-logBody"></tbody>
                 </table>

--- a/templates/roi_selection.html
+++ b/templates/roi_selection.html
@@ -499,7 +499,7 @@
                 tableWrapper.className = 'table-responsive';
 
                 const table = document.createElement('table');
-                table.className = 'table table-hover table-sm mb-0';
+                table.className = 'table table-hover table-striped table-sm mb-0';
                 const thead = document.createElement('thead');
                 const headerRow = document.createElement('tr');
                 ['ID', 'xywh', 'Group', 'Inference Module', 'MQTT', 'Delete'].forEach(colName => {
@@ -600,7 +600,7 @@
                 tableWrapper.className = 'table-responsive';
 
                 const table = document.createElement('table');
-                table.className = 'table table-hover table-sm mb-0';
+                table.className = 'table table-hover table-striped table-sm mb-0';
                 const thead = document.createElement('thead');
                 const headerRow = document.createElement('tr');
                 ['ID', 'xywh', 'Page Name', 'Save Image', 'Action'].forEach(colName => {


### PR DESCRIPTION
## Summary
- add Bootstrap striped styling to data tables across source, MQTT, inference, and ROI pages for alternating row colors

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ce0db0315c832ba65986bff5e4c04d