### PR TITLE
ปรับสไตล์ ROI list card ให้ชิดกรอบ log

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -383,7 +383,7 @@ button.delete {
 
 .cam-row {
   display: flex;
-  align-items: flex-start;
+  align-items: stretch;
   gap: 1.25rem;
   margin-bottom: 2rem;
   flex-wrap: nowrap;
@@ -403,6 +403,8 @@ button.delete {
 
 .roi-list-card {
   flex: 0 0 280px;
+  display: flex;
+  flex-direction: column;
 }
 
 @media (max-width: 992px) {
@@ -421,6 +423,7 @@ button.delete {
   flex-direction: column;
   gap: 0.75rem;
   padding: 0.75rem;
+  flex: 1 1 auto;
 }
 
 .roi-item {


### PR DESCRIPTION
## Summary
- ปรับ flex alignment ของแถวกล้องเพื่อให้ card แต่ละใบยืดเต็มความสูงเท่ากัน
- กำหนด ROI list card ให้เป็น flex column และทำให้ตาราง ROI กินพื้นที่ได้เต็มใบการ์ด

## Testing
- ไม่ได้รันการทดสอบ เนื่องจากเป็นการปรับสไตล์หน้าเว็บเท่านั้น

------
https://chatgpt.com/codex/tasks/task_e_68ce190ede58832bbba37437f93e4f25