### PR TITLE
เพิ่มสกรอลล์ให้ ROI list card

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -383,7 +383,7 @@ button.delete {
 
 .cam-row {
   display: flex;
-  align-items: flex-start;
+  align-items: stretch;
   gap: 1.25rem;
   margin-bottom: 2rem;
   flex-wrap: nowrap;
@@ -403,6 +403,9 @@ button.delete {
 
 .roi-list-card {
   flex: 0 0 280px;
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
 }
 
 @media (max-width: 992px) {
@@ -421,6 +424,9 @@ button.delete {
   flex-direction: column;
   gap: 0.75rem;
   padding: 0.75rem;
+  flex: 1 1 auto;
+  min-height: 0;
+  overflow-y: auto;
 }
 
 .roi-item {


### PR DESCRIPTION
## Summary
- กำหนด min-height ของ ROI list card เพื่อให้กรอบไม่ดันสูงกว่ากรอบ log
- เพิ่มสกรอลล์แนวตั้งในส่วน roi-grid เพื่อรองรับจำนวน ROI ที่มากขึ้นโดยไม่ขยายกรอบเกินไป

## Testing
- ไม่ได้รันทดสอบ เนื่องจากเป็นการปรับสไตล์หน้าเว็บเท่านั้น

------
https://chatgpt.com/codex/tasks/task_e_68ce190ede58832bbba37437f93e4f25