### PR TITLE
Adjust inference layout heights

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -383,7 +383,7 @@ button.delete {
 
 .cam-row {
   display: flex;
-  align-items: stretch;
+  align-items: flex-start;
   gap: 1.25rem;
   margin-bottom: 2rem;
   flex-wrap: nowrap;
@@ -395,6 +395,7 @@ button.delete {
   flex-direction: column;
   gap: 1rem;
   min-width: 0;
+  align-self: flex-start;
 }
 
 .video-card {
@@ -406,6 +407,8 @@ button.delete {
   display: flex;
   flex-direction: column;
   min-height: 0;
+  align-self: stretch;
+  overflow: hidden;
 
 }
 
@@ -428,6 +431,7 @@ button.delete {
   flex: 1 1 auto;
   min-height: 0;
   overflow-y: auto;
+  max-height: 100%;
 
 }
 

--- a/templates/partials/inference_content.html
+++ b/templates/partials/inference_content.html
@@ -38,6 +38,37 @@
 </div>
   <script>
       (function() {
+      function initRoiLayout(cellId) {
+        const videoCell = document.getElementById(cellId);
+        const videoCol = videoCell ? videoCell.closest('.video-col') : null;
+        const roiContainer = document.getElementById(`${cellId}-rois`);
+        const roiCard = roiContainer ? roiContainer.closest('.roi-list-card') : null;
+        if (!videoCol || !roiCard) {
+          return;
+        }
+
+        const roiGrid = roiCard.querySelector('.roi-grid');
+        if (roiGrid) {
+          roiGrid.style.height = '100%';
+        }
+
+        const updateHeight = () => {
+          const rect = videoCol.getBoundingClientRect();
+          if (rect && rect.height) {
+            roiCard.style.maxHeight = `${rect.height}px`;
+          }
+        };
+
+        updateHeight();
+
+        if ('ResizeObserver' in window) {
+          const observer = new ResizeObserver(() => updateHeight());
+          observer.observe(videoCol);
+        }
+
+        window.addEventListener('resize', updateHeight);
+      }
+
       function createCameraController(cellId) {
         let socket;
         let roiSocket;
@@ -632,6 +663,7 @@
     }
 
   // initialize controllers immediately (DOMContentLoaded already fired in fragments)
+  initRoiLayout('cam1');
   const controllers = [
       createCameraController('cam1')
   ];

--- a/templates/partials/inference_page_content.html
+++ b/templates/partials/inference_page_content.html
@@ -41,6 +41,31 @@
 </div>
 <script>
 (function(){
+function initRoiLayout(cellId){
+    const videoCell=document.getElementById(cellId);
+    const videoCol=videoCell?videoCell.closest('.video-col'):null;
+    const roiContainer=document.getElementById(`${cellId}-rois`);
+    const roiCard=roiContainer?roiContainer.closest('.roi-list-card'):null;
+    if(!videoCol||!roiCard){
+        return;
+    }
+    const roiGrid=roiCard.querySelector('.roi-grid');
+    if(roiGrid){
+        roiGrid.style.height='100%';
+    }
+    const updateHeight=()=>{
+        const rect=videoCol.getBoundingClientRect();
+        if(rect&&rect.height){
+            roiCard.style.maxHeight=`${rect.height}px`;
+        }
+    };
+    updateHeight();
+    if('ResizeObserver' in window){
+        const observer=new ResizeObserver(()=>updateHeight());
+        observer.observe(videoCol);
+    }
+    window.addEventListener('resize',updateHeight);
+}
 function createController(cellId){
     let socket;
     let roiSocket;
@@ -548,7 +573,10 @@ function createController(cellId){
         await checkStatus();
     })();
 }
-document.addEventListener('DOMContentLoaded',()=>createController('cam1'));
+document.addEventListener('DOMContentLoaded',()=>{
+    initRoiLayout('cam1');
+    createController('cam1');
+});
 })();
 </script>
 


### PR DESCRIPTION
## Summary
- prevent the inference video column from stretching alongside the ROI list by updating the shared layout styles
- add ResizeObserver-based helpers on the inference group and page templates so the ROI list height tracks the camera column while keeping overflow scrollable

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68ce1bf9c5f4832b862db1322e2a3ca3