### PR TITLE
Ensure inference group ignores page ROIs

### DIFF
--- a/templates/partials/inference_content.html
+++ b/templates/partials/inference_content.html
@@ -176,9 +176,16 @@
             moduleEl.textContent = moduleName ? `โมดูล: ${moduleName}` : 'โมดูล: -';
         }
 
+        function isRoiType(data) {
+            return (data?.type ?? 'roi') === 'roi';
+        }
+
         function ensureRoiItem(id) {
             if (document.getElementById(`${cellId}-roi-${id}`)) return;
             const r = findRoiDataById(id) || { id };
+            if (!isRoiType(r)) {
+                return;
+            }
             const item = document.createElement('div');
             item.className = 'roi-item';
             const title = document.createElement('h4');
@@ -209,6 +216,10 @@
             if (!result) return;
             const roiId = result.id;
             if (roiId === undefined || roiId === null) return;
+            const roiData = findRoiDataById(roiId);
+            if (roiData && !isRoiType(roiData)) {
+                return;
+            }
             ensureRoiItem(roiId);
             updateRoiModuleLabel(roiId, result.module);
             const imgEl = document.getElementById(`${cellId}-roi-${roiId}`);


### PR DESCRIPTION
## Summary
- add an ROI type guard for inference group widgets so page ROIs are ignored
- prevent applying ROI updates for non-ROI entries after reconnects

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68ce1d3d34b0832ba70006e9fee47059