### PR TITLE
Disable page ROI boxes in group inference view

### DIFF
--- a/templates/partials/inference_content.html
+++ b/templates/partials/inference_content.html
@@ -466,7 +466,13 @@
                 startRes = await fetch(`/start_inference/${cam}`, {
                     method: 'POST',
                     headers: {'Content-Type': 'application/json'},
-                    body: JSON.stringify({ ...camCfg, rois, group: requestGroup, interval })
+                    body: JSON.stringify({
+                        ...camCfg,
+                        rois,
+                        group: requestGroup,
+                        interval,
+                        draw_page_boxes: false
+                    })
                 });
                 startData = await startRes.json().catch(() => ({}));
             } catch (err) {


### PR DESCRIPTION
## Summary
- add a draw_page_boxes flag that allows the inference loop to skip drawing page ROI overlays when requested
- have the group inference UI request the backend to hide page ROI boxes while still streaming ROI results

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68ce1f1f77a8832b9cd425bf2a86132d