### PR TITLE
Prevent overlapping log fetch timers

### DIFF
--- a/templates/partials/inference_content.html
+++ b/templates/partials/inference_content.html
@@ -89,6 +89,7 @@
         const logRoiSelect = getEl('logRoiSelect');
         const intervalInput = getEl('intervalInput');
         let logTimer;
+        let isLogUpdating = false;
         let currentLogSource;
         intervalInput.value = localStorage.getItem(`${cellId}-interval`) || '1';
         const groupStorageKey = `${cellId}-group`;
@@ -282,7 +283,11 @@
         function startLogUpdates(sourceName){
             currentLogSource = sourceName;
             stopLogUpdates();
+            isLogUpdating = true;
             async function fetchLog(){
+                if(!isLogUpdating){
+                    return;
+                }
                 try{
                     const res=await fetch(`/read_log?source=${encodeURIComponent(sourceName)}&lines=40&_=${Date.now()}`);
                     const data=await res.json();
@@ -338,13 +343,21 @@
                         }
                     });
                 }catch(e){}
+                finally{
+                    if(isLogUpdating){
+                        logTimer=setTimeout(fetchLog,1000);
+                    }
+                }
             }
             fetchLog();
-            logTimer=setInterval(fetchLog,1000);
         }
 
         function stopLogUpdates(){
-            if(logTimer){clearInterval(logTimer);logTimer=null;}
+            isLogUpdating=false;
+            if(logTimer){
+                clearTimeout(logTimer);
+                logTimer=null;
+            }
             logBody.innerHTML='';
         }
 

--- a/templates/partials/inference_page_content.html
+++ b/templates/partials/inference_page_content.html
@@ -81,6 +81,7 @@ function createController(cellId){
     const logRoiSelect=getEl('logRoiSelect');
     let rois=[];
     let logTimer;
+    let isLogUpdating=false;
 
     function populateLogRoiSelect(){
         logRoiSelect.innerHTML='';
@@ -436,7 +437,11 @@ function createController(cellId){
 
     function startLogUpdates(sourceName){
         stopLogUpdates();
+        isLogUpdating=true;
         async function fetchLog(){
+            if(!isLogUpdating){
+                return;
+            }
             try{
                 const res=await fetch(`/read_log?source=${encodeURIComponent(sourceName)}&lines=40&_=${Date.now()}`);
                 const data=await res.json();
@@ -491,13 +496,21 @@ function createController(cellId){
                     logBody.appendChild(tr);
                 });
             }catch(e){}
+            finally{
+                if(isLogUpdating){
+                    logTimer=setTimeout(fetchLog,1000);
+                }
+            }
         }
         fetchLog();
-        logTimer=setInterval(fetchLog,1000);
     }
 
     function stopLogUpdates(){
-        if(logTimer){clearInterval(logTimer);logTimer=null;}
+        isLogUpdating=false;
+        if(logTimer){
+            clearTimeout(logTimer);
+            logTimer=null;
+        }
         logBody.innerHTML='';
     }
 


### PR DESCRIPTION
## Summary
- update the inference partials to reschedule log polling only after each fetch completes
- reset the polling state and clear timeouts when log updates stop

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68ce23266368832bbea31d2215a868b6