### PR TITLE
Fix log polling race on inference views

### DIFF
--- a/templates/partials/inference_content.html
+++ b/templates/partials/inference_content.html
@@ -90,6 +90,7 @@
         const intervalInput = getEl('intervalInput');
         let logTimer;
         let isLogUpdating = false;
+        let logSessionId = 0;
         let currentLogSource;
         intervalInput.value = localStorage.getItem(`${cellId}-interval`) || '1';
         const groupStorageKey = `${cellId}-group`;
@@ -283,14 +284,18 @@
         function startLogUpdates(sourceName){
             currentLogSource = sourceName;
             stopLogUpdates();
+            const sessionId = logSessionId;
             isLogUpdating = true;
             async function fetchLog(){
-                if(!isLogUpdating){
+                if(!isLogUpdating || sessionId !== logSessionId){
                     return;
                 }
                 try{
                     const res=await fetch(`/read_log?source=${encodeURIComponent(sourceName)}&lines=40&_=${Date.now()}`);
                     const data=await res.json();
+                    if(sessionId !== logSessionId){
+                        return;
+                    }
                     const selectedRoi=logRoiSelect.value;
                     logBody.innerHTML='';
                     const lines=(data.lines||[]).slice().reverse();
@@ -344,7 +349,7 @@
                     });
                 }catch(e){}
                 finally{
-                    if(isLogUpdating){
+                    if(isLogUpdating && sessionId === logSessionId){
                         logTimer=setTimeout(fetchLog,1000);
                     }
                 }
@@ -354,6 +359,7 @@
 
         function stopLogUpdates(){
             isLogUpdating=false;
+            logSessionId++;
             if(logTimer){
                 clearTimeout(logTimer);
                 logTimer=null;

--- a/templates/partials/inference_page_content.html
+++ b/templates/partials/inference_page_content.html
@@ -82,6 +82,7 @@ function createController(cellId){
     let rois=[];
     let logTimer;
     let isLogUpdating=false;
+    let logSessionId=0;
 
     function populateLogRoiSelect(){
         logRoiSelect.innerHTML='';
@@ -437,14 +438,18 @@ function createController(cellId){
 
     function startLogUpdates(sourceName){
         stopLogUpdates();
+        const sessionId=logSessionId;
         isLogUpdating=true;
         async function fetchLog(){
-            if(!isLogUpdating){
+            if(!isLogUpdating||sessionId!==logSessionId){
                 return;
             }
             try{
                 const res=await fetch(`/read_log?source=${encodeURIComponent(sourceName)}&lines=40&_=${Date.now()}`);
                 const data=await res.json();
+                if(sessionId!==logSessionId){
+                    return;
+                }
                 logBody.innerHTML='';
                 const filter=logRoiSelect.value;
                 const lines=(data.lines||[]).slice().reverse();
@@ -497,7 +502,7 @@ function createController(cellId){
                 });
             }catch(e){}
             finally{
-                if(isLogUpdating){
+                if(isLogUpdating&&sessionId===logSessionId){
                     logTimer=setTimeout(fetchLog,1000);
                 }
             }
@@ -507,6 +512,7 @@ function createController(cellId){
 
     function stopLogUpdates(){
         isLogUpdating=false;
+        logSessionId++;
         if(logTimer){
             clearTimeout(logTimer);
             logTimer=null;


### PR DESCRIPTION
## Summary
- guard inference group log polling with a session id to prevent stale fetch loops from continuing after switching sources
- apply the same session-aware timeout protection to the inference page log polling

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68ce27235a7c832ba95427267e2c42ea