### PR TITLE
Enhance stream row separation on inference views

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -382,11 +382,42 @@ button.delete {
 }
 
 .cam-row {
+  position: relative;
   display: flex;
   align-items: flex-start;
-  gap: 1.25rem;
-  margin-bottom: 2rem;
+  gap: 1.5rem;
+  margin-bottom: 2.5rem;
   flex-wrap: nowrap;
+  padding: 1.75rem 1.75rem 1.5rem;
+  border-radius: 26px;
+  background: linear-gradient(140deg, rgba(255, 255, 255, 0.95), rgba(241, 245, 249, 0.88));
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  box-shadow: 0 32px 55px -32px rgba(15, 23, 42, 0.65);
+}
+
+.cam-row::before {
+  content: attr(data-row-label);
+  position: absolute;
+  top: -0.95rem;
+  left: 2.25rem;
+  padding: 0.35rem 0.95rem;
+  border-radius: 999px;
+  font-size: 0.9rem;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  color: #0f172a;
+  background: linear-gradient(135deg, rgba(59, 130, 246, 0.2), rgba(14, 165, 233, 0.18));
+  border: 1px solid rgba(37, 99, 235, 0.35);
+  box-shadow: 0 10px 25px -18px rgba(15, 23, 42, 0.5);
+}
+
+.cam-row::after {
+  content: "";
+  position: absolute;
+  inset: 0.75rem;
+  border-radius: 20px;
+  border: 1px dashed rgba(37, 99, 235, 0.25);
+  pointer-events: none;
 }
 
 .video-col {
@@ -415,6 +446,8 @@ button.delete {
 @media (max-width: 992px) {
   .cam-row {
     flex-direction: column;
+    padding: 1.25rem;
+    gap: 1.25rem;
   }
 
   .roi-list-card {

--- a/templates/partials/inference_content.html
+++ b/templates/partials/inference_content.html
@@ -1,5 +1,5 @@
 
-<div class="cam-row">
+<div class="cam-row" data-row-label="สตรีม 1">
     <div class="video-col">
         <div class="card roi-card video-card">
             <div id="cam1" class="cam-cell">
@@ -37,7 +37,7 @@
     </div>
 </div>
 
-<div class="cam-row mt-4">
+<div class="cam-row mt-4" data-row-label="สตรีม 2">
     <div class="video-col">
         <div class="card roi-card video-card">
             <div id="cam2" class="cam-cell">

--- a/templates/partials/inference_page_content.html
+++ b/templates/partials/inference_page_content.html
@@ -1,5 +1,5 @@
 
-<div class="cam-row">
+<div class="cam-row" data-row-label="สตรีม 1">
     <div class="video-col">
         <div class="card roi-card video-card">
             <div id="cam1" class="cam-cell">


### PR DESCRIPTION
## Summary
- add row labels to inference group and page stream sections
- refresh stream row styling with highlighted backgrounds, dashed outlines, and spacing for clearer separation

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68ce4d22d908832bb9fdcd9fc587e22c