### PR TITLE
ปรับพื้นหลังหัวข้อสตรีมให้ทึบ

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -406,8 +406,8 @@ button.delete {
   font-weight: 600;
   letter-spacing: 0.02em;
   color: #0f172a;
-  background: linear-gradient(135deg, rgba(59, 130, 246, 0.2), rgba(14, 165, 233, 0.18));
-  border: 1px solid rgba(37, 99, 235, 0.35);
+  background: linear-gradient(135deg, #60a5fa, #38bdf8);
+  border: 1px solid rgba(37, 99, 235, 0.6);
   box-shadow: 0 10px 25px -18px rgba(15, 23, 42, 0.5);
 }
 


### PR DESCRIPTION
## Summary
- ปรับสีพื้นหลังป้ายหัวข้อแถวกล้องให้เป็นไล่เฉดสีทึบเพื่อให้ "สตรีม 1" และ "สตรีม 2" มองเห็นชัดเจน

## Testing
- Not Run (ไม่พบคำสั่งทดสอบที่ต้องรัน)


------
https://chatgpt.com/codex/tasks/task_e_68ce4fe020d4832baee1a0496a445205