### PR TITLE
Add inference hub page and session tracking

### DIFF
--- a/app.py
+++ b/app.py
@@ -781,12 +781,22 @@ async def roi_page():
 
 
 @app.route("/inference")
-async def inference() -> str:
+async def inference_hub() -> str:
     return await render_template("inference.html")
+
+
+@app.route("/inference/group")
+async def inference_group() -> str:
+    return await render_template("inference_group.html")
 
 
 @app.route("/inference_page")
 async def inference_page() -> str:
+    return await render_template("inference_page.html")
+
+
+@app.route("/inference/page")
+async def inference_page_alias() -> str:
     return await render_template("inference_page.html")
 
 

--- a/app.py
+++ b/app.py
@@ -796,13 +796,18 @@ async def inference_group_session(session_id: str) -> str:
 
 
 @app.route("/inference_page")
-async def inference_page() -> str:
-    return await render_template("inference_page.html")
+async def inference_page_legacy() -> str:
+    return await render_template("inference_page.html", session_id=None)
 
 
 @app.route("/inference/page")
-async def inference_page_alias() -> str:
-    return await render_template("inference_page.html")
+async def inference_page_template() -> str:
+    return await render_template("inference_page.html", session_id=None)
+
+
+@app.route("/inference/page/<string:session_id>")
+async def inference_page_session(session_id: str) -> str:
+    return await render_template("inference_page.html", session_id=session_id)
 
 
 # Health & quit endpoints (used by systemd)

--- a/app.py
+++ b/app.py
@@ -786,8 +786,13 @@ async def inference_hub() -> str:
 
 
 @app.route("/inference/group")
-async def inference_group() -> str:
-    return await render_template("inference_group.html")
+async def inference_group_template() -> str:
+    return await render_template("inference_group.html", session_id=None)
+
+
+@app.route("/inference/group/<string:session_id>")
+async def inference_group_session(session_id: str) -> str:
+    return await render_template("inference_group.html", session_id=session_id)
 
 
 @app.route("/inference_page")

--- a/static/js/inference-dashboard.js
+++ b/static/js/inference-dashboard.js
@@ -1,0 +1,177 @@
+(function () {
+  const registry = window.InferenceSessions;
+  if (!registry) {
+    return;
+  }
+
+  const container = document.getElementById('inferenceSessionsContainer');
+  const emptyState = document.getElementById('inferenceSessionsEmpty');
+  const refreshBtn = document.getElementById('refreshSessions');
+  const clearBtn = document.getElementById('clearSessions');
+
+  const STATUS_BADGES = {
+    running: { text: 'กำลังทำงาน', className: 'badge bg-success-subtle text-success' },
+    stopped: { text: 'หยุดแล้ว', className: 'badge bg-secondary-subtle text-secondary' },
+    error: { text: 'ผิดพลาด', className: 'badge bg-danger-subtle text-danger' },
+  };
+
+  function formatRelativeTime(timestamp) {
+    if (!timestamp) {
+      return '—';
+    }
+    const diff = Date.now() - timestamp;
+    const seconds = Math.max(0, Math.floor(diff / 1000));
+    if (seconds < 45) {
+      return 'ไม่กี่วินาทีที่แล้ว';
+    }
+    const minutes = Math.floor(seconds / 60);
+    if (minutes < 60) {
+      return `${minutes} นาทีที่แล้ว`;
+    }
+    const hours = Math.floor(minutes / 60);
+    if (hours < 24) {
+      return `${hours} ชั่วโมงที่แล้ว`;
+    }
+    const days = Math.floor(hours / 24);
+    if (days < 7) {
+      return `${days} วันที่แล้ว`;
+    }
+    const date = new Date(timestamp);
+    return date.toLocaleString('th-TH', {
+      year: 'numeric',
+      month: 'short',
+      day: 'numeric',
+      hour: '2-digit',
+      minute: '2-digit',
+    });
+  }
+
+  function createSessionElement(session) {
+    const item = document.createElement('article');
+    item.className = 'inference-session-item';
+
+    const header = document.createElement('div');
+    header.className = 'inference-session-item__header';
+
+    const typeBadge = document.createElement('span');
+    typeBadge.className = 'badge rounded-pill inference-session-item__type';
+    typeBadge.textContent = session.type === 'page' ? 'Page Inference' : 'Group Inference';
+    header.appendChild(typeBadge);
+
+    const statusInfo = STATUS_BADGES[session.status] || STATUS_BADGES.running;
+    const statusBadge = document.createElement('span');
+    statusBadge.className = statusInfo.className + ' inference-session-item__status';
+    statusBadge.textContent = statusInfo.text;
+    header.appendChild(statusBadge);
+
+    const title = document.createElement('h3');
+    title.className = 'inference-session-item__title';
+    title.textContent = session.title || 'Inference';
+
+    const metaList = document.createElement('dl');
+    metaList.className = 'inference-session-item__meta';
+
+    function addMeta(label, value, icon) {
+      if (!value) {
+        return;
+      }
+      const dt = document.createElement('dt');
+      dt.innerHTML = icon ? `<i class="${icon}"></i>${label}` : label;
+      const dd = document.createElement('dd');
+      dd.textContent = value;
+      metaList.appendChild(dt);
+      metaList.appendChild(dd);
+    }
+
+    if (session.sourceName || session.sourceId) {
+      addMeta('Source', session.sourceName || session.sourceId, 'bi bi-camera-video me-1');
+    }
+    if (session.group) {
+      addMeta('Group', session.group, 'bi bi-collection me-1');
+    }
+    if (session.page) {
+      addMeta('Page', session.page, 'bi bi-file-earmark-text me-1');
+    }
+
+    const footer = document.createElement('div');
+    footer.className = 'inference-session-item__footer';
+
+    const timeInfo = document.createElement('div');
+    timeInfo.className = 'inference-session-item__time text-muted';
+    timeInfo.textContent = `อัปเดตล่าสุด ${formatRelativeTime(session.updatedAt)}`;
+
+    const actions = document.createElement('div');
+    actions.className = 'inference-session-item__actions';
+
+    const openLink = document.createElement('a');
+    openLink.className = 'btn btn-primary btn-sm';
+    openLink.href = session.href || '/inference';
+    openLink.innerHTML = '<i class="bi bi-box-arrow-up-right me-1"></i>เปิดหน้า';
+    actions.appendChild(openLink);
+
+    const removeBtn = document.createElement('button');
+    removeBtn.className = 'btn btn-outline-danger btn-sm';
+    removeBtn.type = 'button';
+    removeBtn.innerHTML = '<i class="bi bi-x-lg me-1"></i>นำออก';
+    removeBtn.addEventListener('click', () => {
+      const confirmed = window.confirm('ต้องการนำรายการนี้ออกจากหน้าสรุปหรือไม่?');
+      if (confirmed) {
+        registry.remove(session.id);
+      }
+    });
+    actions.appendChild(removeBtn);
+
+    item.appendChild(header);
+    item.appendChild(title);
+    item.appendChild(metaList);
+    footer.appendChild(timeInfo);
+    footer.appendChild(actions);
+    item.appendChild(footer);
+
+    return item;
+  }
+
+  function renderSessions(list) {
+    container.innerHTML = '';
+    if (!list || list.length === 0) {
+      container.classList.add('is-empty');
+      emptyState.classList.remove('d-none');
+      return;
+    }
+    container.classList.remove('is-empty');
+    emptyState.classList.add('d-none');
+
+    list.forEach((session) => {
+      const element = createSessionElement(session);
+      container.appendChild(element);
+    });
+  }
+
+  function refresh() {
+    renderSessions(registry.getAll());
+  }
+
+  refreshBtn?.addEventListener('click', () => {
+    refresh();
+  });
+
+  clearBtn?.addEventListener('click', () => {
+    const confirmed = window.confirm('ต้องการล้างรายการทั้งหมดหรือไม่?');
+    if (confirmed) {
+      registry.clear();
+    }
+  });
+
+  window.addEventListener('inferenceSessions:change', (event) => {
+    const list = Array.isArray(event.detail) ? event.detail : registry.getAll();
+    renderSessions(list);
+  });
+
+  window.addEventListener('storage', (event) => {
+    if (event.key === registry.storageKey) {
+      refresh();
+    }
+  });
+
+  refresh();
+})();

--- a/static/js/inference-dashboard.js
+++ b/static/js/inference-dashboard.js
@@ -86,6 +86,10 @@
       if (event.button && event.button !== 0) {
         return;
       }
+      const type = link.getAttribute('data-inference-type') || '';
+      if (type === 'group') {
+        return;
+      }
       event.preventDefault();
       const camId = resolveNextCamId();
       const target = buildTargetHref(link.getAttribute('href'), camId);

--- a/static/js/inference-sessions.js
+++ b/static/js/inference-sessions.js
@@ -1,0 +1,126 @@
+(function (window) {
+  const STORAGE_KEY = 'visionroi_inference_sessions';
+
+  function readSessions() {
+    try {
+      const raw = localStorage.getItem(STORAGE_KEY);
+      if (!raw) {
+        return [];
+      }
+      const parsed = JSON.parse(raw);
+      if (!Array.isArray(parsed)) {
+        return [];
+      }
+      return parsed;
+    } catch (err) {
+      console.warn('Failed to parse inference sessions from storage', err);
+      return [];
+    }
+  }
+
+  function writeSessions(list) {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(list));
+    return list;
+  }
+
+  function emitChange(list) {
+    window.dispatchEvent(
+      new CustomEvent('inferenceSessions:change', {
+        detail: list.slice(),
+      })
+    );
+  }
+
+  function normalizeSession(session) {
+    const now = Date.now();
+    return {
+      id: String(session.id ?? ''),
+      type: session.type === 'page' ? 'page' : 'group',
+      title: session.title || 'Inference',
+      sourceId: session.sourceId || '',
+      sourceName: session.sourceName || '',
+      group: session.group || '',
+      page: session.page || '',
+      href: session.href || '/inference',
+      status: session.status || 'running',
+      createdAt: session.createdAt || now,
+      updatedAt: session.updatedAt || now,
+      meta: session.meta || {},
+    };
+  }
+
+  function sortSessions(list) {
+    return list
+      .slice()
+      .sort((a, b) => (b.updatedAt || 0) - (a.updatedAt || 0));
+  }
+
+  function upsertSession(data) {
+    const sessions = readSessions();
+    const normalized = normalizeSession(data);
+    if (!normalized.id) {
+      return;
+    }
+    const idx = sessions.findIndex((item) => item.id === normalized.id);
+    if (idx > -1) {
+      const merged = {
+        ...sessions[idx],
+        ...normalized,
+        createdAt: sessions[idx].createdAt || normalized.createdAt,
+        updatedAt: Date.now(),
+      };
+      sessions[idx] = merged;
+    } else {
+      sessions.push({ ...normalized, createdAt: Date.now(), updatedAt: Date.now() });
+    }
+    const finalList = writeSessions(sessions);
+    emitChange(sortSessions(finalList));
+  }
+
+  function updateSession(id, updates) {
+    if (!id) return;
+    if (typeof updates !== 'object' || updates === null) {
+      updates = {};
+    }
+    const sessions = readSessions();
+    const idx = sessions.findIndex((item) => item.id === id);
+    if (idx === -1) {
+      return;
+    }
+    const now = Date.now();
+    const merged = {
+      ...sessions[idx],
+      ...updates,
+      updatedAt: now,
+    };
+    sessions[idx] = merged;
+    const finalList = writeSessions(sessions);
+    emitChange(sortSessions(finalList));
+  }
+
+  function removeSession(id) {
+    if (!id) return;
+    const sessions = readSessions();
+    const next = sessions.filter((item) => item.id !== id);
+    const finalList = writeSessions(next);
+    emitChange(sortSessions(finalList));
+  }
+
+  function clearSessions() {
+    localStorage.removeItem(STORAGE_KEY);
+    emitChange([]);
+  }
+
+  function getAllSessions() {
+    return sortSessions(readSessions());
+  }
+
+  window.InferenceSessions = {
+    storageKey: STORAGE_KEY,
+    getAll: getAllSessions,
+    upsertSession,
+    updateSession,
+    remove: removeSession,
+    clear: clearSessions,
+  };
+})(window);

--- a/static/style.css
+++ b/static/style.css
@@ -198,6 +198,255 @@ main.app-main {
   color: rgba(15, 23, 42, 0.78);
 }
 
+.inference-hub {
+  display: flex;
+  flex-direction: column;
+  gap: 2.5rem;
+}
+
+.inference-hero {
+  position: relative;
+  overflow: hidden;
+  background: linear-gradient(135deg, rgba(37, 99, 235, 0.95), rgba(14, 165, 233, 0.88));
+  color: #fff;
+  padding: clamp(2rem, 3vw, 3rem);
+}
+
+.inference-hero::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(circle at 15% 25%, rgba(255, 255, 255, 0.18), transparent 55%),
+    radial-gradient(circle at 75% 10%, rgba(255, 255, 255, 0.12), transparent 60%);
+  pointer-events: none;
+}
+
+.inference-hero__badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.35rem 0.85rem;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.18);
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  font-size: 0.75rem;
+  position: relative;
+  z-index: 1;
+}
+
+.inference-hero__title {
+  font-size: clamp(1.75rem, 3vw, 2.5rem);
+  font-weight: 700;
+  margin-top: 1rem;
+  margin-bottom: 0.5rem;
+  position: relative;
+  z-index: 1;
+}
+
+.inference-hero__subtitle {
+  max-width: 60ch;
+  font-size: 1rem;
+  margin-bottom: 1.75rem;
+  color: rgba(255, 255, 255, 0.85);
+  position: relative;
+  z-index: 1;
+}
+
+.inference-hero__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+  position: relative;
+  z-index: 1;
+}
+
+.inference-hero__actions .btn-outline-light {
+  border-color: rgba(255, 255, 255, 0.65);
+  color: #fff;
+}
+
+.inference-create-options {
+  gap: 1.5rem;
+}
+
+.inference-option {
+  display: flex;
+  flex-direction: row;
+  gap: 1.25rem;
+  text-decoration: none;
+  color: inherit;
+  padding: 1.75rem;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+  border: 1px solid rgba(37, 99, 235, 0.12);
+}
+
+.inference-option:hover,
+.inference-option:focus {
+  transform: translateY(-4px);
+  box-shadow: 0 32px 45px -35px rgba(15, 23, 42, 0.75);
+  text-decoration: none;
+}
+
+.inference-option__icon {
+  width: 64px;
+  height: 64px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 18px;
+  font-size: 1.75rem;
+}
+
+.inference-option__title {
+  font-size: 1.35rem;
+  font-weight: 600;
+  margin-bottom: 0.4rem;
+}
+
+.inference-option__desc {
+  margin-bottom: 0.75rem;
+  color: var(--color-muted);
+}
+
+.inference-option__list {
+  padding-left: 1.25rem;
+  margin-bottom: 0.75rem;
+  color: var(--color-muted);
+}
+
+.inference-list {
+  padding: 2rem;
+}
+
+.inference-list__title {
+  font-size: 1.4rem;
+  font-weight: 600;
+  margin-bottom: 0.25rem;
+}
+
+.inference-list__subtitle {
+  color: var(--color-muted);
+}
+
+.inference-sessions {
+  display: grid;
+  gap: 1.25rem;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+}
+
+.inference-session-item {
+  border: 1px solid rgba(15, 23, 42, 0.08);
+  border-radius: 18px;
+  padding: 1.35rem;
+  background: rgba(255, 255, 255, 0.9);
+  box-shadow: 0 24px 45px -32px rgba(15, 23, 42, 0.65);
+  display: flex;
+  flex-direction: column;
+  gap: 0.85rem;
+}
+
+.inference-session-item__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.inference-session-item__title {
+  font-size: 1.15rem;
+  font-weight: 600;
+  margin: 0;
+}
+
+.inference-session-item__meta {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 0.25rem 0.75rem;
+  margin: 0;
+}
+
+.inference-session-item__meta dt {
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: var(--color-muted);
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+}
+
+.inference-session-item__meta dd {
+  margin: 0;
+  font-size: 0.95rem;
+}
+
+.inference-session-item__footer {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.inference-session-item__actions {
+  display: flex;
+  gap: 0.75rem;
+}
+
+.inference-empty {
+  border: 2px dashed rgba(148, 163, 184, 0.35);
+  border-radius: 18px;
+  background: rgba(15, 23, 42, 0.03);
+  margin-top: 2rem;
+}
+
+.inference-empty__icon {
+  display: inline-flex;
+  width: 72px;
+  height: 72px;
+  border-radius: 50%;
+  align-items: center;
+  justify-content: center;
+  background: rgba(37, 99, 235, 0.1);
+  color: var(--color-primary);
+  font-size: 2rem;
+  margin-bottom: 1rem;
+}
+
+.inference-empty__title {
+  font-weight: 600;
+  margin-bottom: 0.25rem;
+}
+
+.inference-empty__desc {
+  color: var(--color-muted);
+  max-width: 50ch;
+  margin: 0 auto;
+}
+
+@media (max-width: 768px) {
+  .inference-option {
+    flex-direction: column;
+    text-align: center;
+    align-items: center;
+  }
+
+  .inference-session-item__footer {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .inference-session-item__actions {
+    width: 100%;
+    justify-content: flex-start;
+    flex-wrap: wrap;
+  }
+
+  .inference-hero__actions {
+    flex-direction: column;
+    align-items: stretch;
+  }
+}
+
 .dashboard {
   display: flex;
   flex-direction: column;

--- a/static/style.css
+++ b/static/style.css
@@ -899,6 +899,77 @@ button.delete {
   box-shadow: 0 20px 40px -30px rgba(15, 23, 42, 0.6);
 }
 
+.inference-session-toolbar {
+  padding: 1.5rem 1.75rem;
+  border-radius: 24px;
+  background: linear-gradient(135deg, rgba(59, 130, 246, 0.12), rgba(14, 165, 233, 0.08));
+  border: 1px solid rgba(59, 130, 246, 0.18);
+  color: var(--color-text);
+}
+
+.inference-session-toolbar__body {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  flex-wrap: wrap;
+  gap: 1.25rem;
+}
+
+.inference-session-toolbar__info {
+  flex: 1 1 320px;
+  min-width: 0;
+}
+
+.inference-session-toolbar__title {
+  font-size: 1.6rem;
+  font-weight: 700;
+  margin-bottom: 0.35rem;
+  color: #0f172a;
+}
+
+.inference-session-toolbar__subtitle {
+  margin: 0;
+  color: rgba(15, 23, 42, 0.72);
+  font-size: 0.98rem;
+}
+
+.inference-session-toolbar__actions {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
+.inference-session-toolbar__badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  font-size: 0.95rem;
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  box-shadow: 0 10px 25px -18px rgba(59, 130, 246, 0.55);
+}
+
+.inference-session-toolbar__badge strong {
+  font-weight: 700;
+  color: inherit;
+}
+
+@media (max-width: 768px) {
+  .inference-session-toolbar {
+    padding: 1.25rem 1.25rem;
+  }
+
+  .inference-session-toolbar__title {
+    font-size: 1.35rem;
+  }
+
+  .inference-session-toolbar__actions {
+    width: 100%;
+    justify-content: flex-start;
+  }
+}
+
 .cam-row {
   position: relative;
   display: flex;

--- a/templates/base.html
+++ b/templates/base.html
@@ -75,6 +75,7 @@
     </div>
   </nav>
   {% include 'partials/alert.html' %}
+  <script src="{{ url_for('static', filename='js/inference-sessions.js') }}"></script>
   <main id="content" class="app-main">
     <div class="{% block shell_classes %}app-shell container-xxl{% endblock %}">
       {% block content %}{% endblock %}
@@ -82,7 +83,6 @@
   </main>
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
   <script src="{{ url_for('static', filename='js/bootstrap-init.js') }}"></script>
-  <script src="{{ url_for('static', filename='js/inference-sessions.js') }}"></script>
   <script>
     function setActiveLink(path) {
       document.querySelectorAll('.navbar-nav .nav-link').forEach(link => {

--- a/templates/base.html
+++ b/templates/base.html
@@ -59,13 +59,13 @@
             </a>
           </li>
           <li class="nav-item">
-            <a href="/inference" class="nav-link" data-bs-toggle="tooltip" title="Inference Group">
+            <a href="/inference" class="nav-link" data-bs-toggle="tooltip" title="Inference Hub" data-active-paths="/inference,/inference/group">
               <i class="bi bi-cpu me-2"></i>
-              <span>Inference Group</span>
+              <span>Inference Hub</span>
             </a>
           </li>
           <li class="nav-item">
-            <a href="/inference_page" class="nav-link" data-bs-toggle="tooltip" title="Inference Page">
+            <a href="/inference/page" class="nav-link" data-bs-toggle="tooltip" title="Inference Page" data-active-paths="/inference/page,/inference_page">
               <i class="bi bi-kanban me-2"></i>
               <span>Inference Page</span>
             </a>
@@ -82,15 +82,19 @@
   </main>
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
   <script src="{{ url_for('static', filename='js/bootstrap-init.js') }}"></script>
+  <script src="{{ url_for('static', filename='js/inference-sessions.js') }}"></script>
   <script>
     function setActiveLink(path) {
       document.querySelectorAll('.navbar-nav .nav-link').forEach(link => {
-        link.classList.toggle('active', link.getAttribute('href') === path);
+        const dataPaths = link.getAttribute('data-active-paths');
+        const paths = dataPaths ? dataPaths.split(',') : [link.getAttribute('href')];
+        link.classList.toggle('active', paths.includes(path));
       });
     }
     window.addEventListener('DOMContentLoaded', () => {
       setActiveLink(window.location.pathname);
     });
   </script>
+  {% block extra_scripts %}{% endblock %}
 </body>
 </html>

--- a/templates/inference.html
+++ b/templates/inference.html
@@ -13,7 +13,7 @@
       <a class="btn btn-primary btn-lg js-create-inference" href="{{ url_for('inference_group_template') }}" data-inference-type="group">
         <i class="bi bi-cpu me-2"></i>เริ่มสร้าง Group Inference
       </a>
-      <a class="btn btn-outline-light btn-lg js-create-inference" href="{{ url_for('inference_page_alias') }}" data-inference-type="page">
+      <a class="btn btn-outline-light btn-lg js-create-inference" href="{{ url_for('inference_page_template') }}" data-inference-type="page">
         <i class="bi bi-kanban me-2"></i>เริ่มสร้าง Page Inference
       </a>
     </div>
@@ -38,7 +38,7 @@
       </a>
     </div>
     <div class="col-lg-6">
-      <a href="{{ url_for('inference_page_alias') }}" class="inference-option card h-100 js-create-inference" data-inference-type="page">
+      <a href="{{ url_for('inference_page_template') }}" class="inference-option card h-100 js-create-inference" data-inference-type="page">
         <div class="inference-option__icon bg-info-subtle text-info">
           <i class="bi bi-layout-text-sidebar-reverse"></i>
         </div>

--- a/templates/inference.html
+++ b/templates/inference.html
@@ -10,10 +10,10 @@
       เมื่อเริ่มสตรีม ระบบจะบันทึกรายการไว้ในหน้านี้ให้อัตโนมัติ เพื่อกลับมาตรวจสอบสถานะได้ง่ายขึ้น
     </p>
     <div class="inference-hero__actions">
-      <a class="btn btn-primary btn-lg" href="{{ url_for('inference_group') }}">
+      <a class="btn btn-primary btn-lg js-create-inference" href="{{ url_for('inference_group') }}" data-inference-type="group">
         <i class="bi bi-cpu me-2"></i>เริ่มสร้าง Group Inference
       </a>
-      <a class="btn btn-outline-light btn-lg" href="{{ url_for('inference_page_alias') }}">
+      <a class="btn btn-outline-light btn-lg js-create-inference" href="{{ url_for('inference_page_alias') }}" data-inference-type="page">
         <i class="bi bi-kanban me-2"></i>เริ่มสร้าง Page Inference
       </a>
     </div>
@@ -21,7 +21,7 @@
 
   <section class="row g-4 inference-create-options">
     <div class="col-lg-6">
-      <a href="{{ url_for('inference_group') }}" class="inference-option card h-100">
+      <a href="{{ url_for('inference_group') }}" class="inference-option card h-100 js-create-inference" data-inference-type="group">
         <div class="inference-option__icon bg-primary-subtle text-primary">
           <i class="bi bi-grid-1x2-fill"></i>
         </div>
@@ -38,7 +38,7 @@
       </a>
     </div>
     <div class="col-lg-6">
-      <a href="{{ url_for('inference_page_alias') }}" class="inference-option card h-100">
+      <a href="{{ url_for('inference_page_alias') }}" class="inference-option card h-100 js-create-inference" data-inference-type="page">
         <div class="inference-option__icon bg-info-subtle text-info">
           <i class="bi bi-layout-text-sidebar-reverse"></i>
         </div>

--- a/templates/inference.html
+++ b/templates/inference.html
@@ -1,8 +1,88 @@
 {% extends "base.html" %}
-{% block title %}Inference Group{% endblock %}
-
-{% block shell_classes %}app-shell app-shell--fluid{% endblock %}
-
+{% block title %}Inference Hub{% endblock %}
 {% block content %}
-{% include 'partials/inference_content.html' %}
+<div class="inference-hub">
+  <section class="card inference-hero">
+    <div class="inference-hero__badge">ศูนย์ควบคุม Inference</div>
+    <h1 class="inference-hero__title">จัดการงานวิเคราะห์ภาพได้อย่างยืดหยุ่น</h1>
+    <p class="inference-hero__subtitle">
+      เลือกสร้างชุดงานแบบ Group หรือ Page เพื่อเข้าสู่หน้าจอเดิมที่คุ้นเคย แล้วเริ่มสตรีมจากแหล่งวิดีโอที่ต้องการ
+      เมื่อเริ่มสตรีม ระบบจะบันทึกรายการไว้ในหน้านี้ให้อัตโนมัติ เพื่อกลับมาตรวจสอบสถานะได้ง่ายขึ้น
+    </p>
+    <div class="inference-hero__actions">
+      <a class="btn btn-primary btn-lg" href="{{ url_for('inference_group') }}">
+        <i class="bi bi-cpu me-2"></i>เริ่มสร้าง Group Inference
+      </a>
+      <a class="btn btn-outline-light btn-lg" href="{{ url_for('inference_page_alias') }}">
+        <i class="bi bi-kanban me-2"></i>เริ่มสร้าง Page Inference
+      </a>
+    </div>
+  </section>
+
+  <section class="row g-4 inference-create-options">
+    <div class="col-lg-6">
+      <a href="{{ url_for('inference_group') }}" class="inference-option card h-100">
+        <div class="inference-option__icon bg-primary-subtle text-primary">
+          <i class="bi bi-grid-1x2-fill"></i>
+        </div>
+        <div>
+          <h2 class="inference-option__title">Group Inference</h2>
+          <p class="inference-option__desc">เหมาะสำหรับการจัดกลุ่ม ROI หลายรายการ เพื่อสลับดูผลได้ตามกลุ่มที่สร้างไว้</p>
+          <ul class="inference-option__list">
+            <li>รองรับหลายสตรีมพร้อมกัน</li>
+            <li>เลือกกลุ่ม ROI ที่ต้องการได้ทันที</li>
+            <li>ผูกกับข้อมูลเดิมของแต่ละแหล่งวิดีโอ</li>
+          </ul>
+          <span class="btn btn-outline-primary mt-2">ไปที่หน้า Group Inference</span>
+        </div>
+      </a>
+    </div>
+    <div class="col-lg-6">
+      <a href="{{ url_for('inference_page_alias') }}" class="inference-option card h-100">
+        <div class="inference-option__icon bg-info-subtle text-info">
+          <i class="bi bi-layout-text-sidebar-reverse"></i>
+        </div>
+        <div>
+          <h2 class="inference-option__title">Page Inference</h2>
+          <p class="inference-option__desc">ออกแบบสำหรับงานที่ต้องติดตามคะแนนของแต่ละหน้า พร้อมตารางสรุปผลแบบเรียลไทม์</p>
+          <ul class="inference-option__list">
+            <li>ดึงผลคะแนนของแต่ละหน้าได้ทันที</li>
+            <li>ดูตารางสรุปผลพร้อมวิดีโอสตรีม</li>
+            <li>ตั้งค่าเวลาและ ROI ได้อย่างยืดหยุ่น</li>
+          </ul>
+          <span class="btn btn-outline-info mt-2">ไปที่หน้า Page Inference</span>
+        </div>
+      </a>
+    </div>
+  </section>
+
+  <section class="card inference-list">
+    <div class="d-flex flex-wrap align-items-center justify-content-between gap-3">
+      <div>
+        <h2 class="inference-list__title">รายการ Inference ที่สร้างไว้</h2>
+        <p class="inference-list__subtitle mb-0">ระบบจะอัปเดตสถานะให้อัตโนมัติเมื่อคุณเริ่มหรือหยุดสตรีม</p>
+      </div>
+      <div class="btn-group">
+        <button id="refreshSessions" class="btn btn-outline-secondary btn-sm" type="button">
+          <i class="bi bi-arrow-clockwise me-1"></i>รีเฟรช
+        </button>
+        <button id="clearSessions" class="btn btn-outline-danger btn-sm" type="button">
+          <i class="bi bi-trash3 me-1"></i>ล้างรายการทั้งหมด
+        </button>
+      </div>
+    </div>
+
+    <div id="inferenceSessionsContainer" class="inference-sessions mt-4"></div>
+    <div id="inferenceSessionsEmpty" class="inference-empty text-center py-5">
+      <div class="inference-empty__icon">
+        <i class="bi bi-collection-play"></i>
+      </div>
+      <h3 class="inference-empty__title">ยังไม่มีรายการที่บันทึกไว้</h3>
+      <p class="inference-empty__desc mb-0">ไปยังหน้าที่ต้องการ สร้างงานใหม่ เลือก Source และกด Start เพื่อให้ระบบนำมาขึ้นรายการที่นี่</p>
+    </div>
+  </section>
+</div>
+{% endblock %}
+{% block extra_scripts %}
+  <script src="{{ url_for('static', filename='js/inference-dashboard.js') }}"></script>
 {% endblock %}

--- a/templates/inference.html
+++ b/templates/inference.html
@@ -10,7 +10,7 @@
       เมื่อเริ่มสตรีม ระบบจะบันทึกรายการไว้ในหน้านี้ให้อัตโนมัติ เพื่อกลับมาตรวจสอบสถานะได้ง่ายขึ้น
     </p>
     <div class="inference-hero__actions">
-      <a class="btn btn-primary btn-lg js-create-inference" href="{{ url_for('inference_group') }}" data-inference-type="group">
+      <a class="btn btn-primary btn-lg js-create-inference" href="{{ url_for('inference_group_template') }}" data-inference-type="group">
         <i class="bi bi-cpu me-2"></i>เริ่มสร้าง Group Inference
       </a>
       <a class="btn btn-outline-light btn-lg js-create-inference" href="{{ url_for('inference_page_alias') }}" data-inference-type="page">
@@ -21,7 +21,7 @@
 
   <section class="row g-4 inference-create-options">
     <div class="col-lg-6">
-      <a href="{{ url_for('inference_group') }}" class="inference-option card h-100 js-create-inference" data-inference-type="group">
+      <a href="{{ url_for('inference_group_template') }}" class="inference-option card h-100 js-create-inference" data-inference-type="group">
         <div class="inference-option__icon bg-primary-subtle text-primary">
           <i class="bi bi-grid-1x2-fill"></i>
         </div>

--- a/templates/inference_group.html
+++ b/templates/inference_group.html
@@ -1,0 +1,6 @@
+{% extends "base.html" %}
+{% block title %}Inference Group{% endblock %}
+{% block shell_classes %}app-shell app-shell--fluid{% endblock %}
+{% block content %}
+{% include 'partials/inference_content.html' %}
+{% endblock %}

--- a/templates/partials/inference_content.html
+++ b/templates/partials/inference_content.html
@@ -39,6 +39,73 @@
 
   <script>
       (function() {
+      const DEFAULT_CELL_ID = 'cam1';
+
+      function resolveCellId(defaultId) {
+        const raw = String(window.location.hash || '').replace(/^#/, '').trim();
+        if (!raw) {
+          return defaultId;
+        }
+        const match = /^cam(\d+)$/i.exec(raw);
+        if (!match) {
+          return defaultId;
+        }
+        const num = parseInt(match[1], 10);
+        return Number.isFinite(num) && num > 0 ? `cam${num}` : defaultId;
+      }
+
+      function ensureLocationHash(cellId) {
+        const expectedHash = `#${cellId}`;
+        if (window.location.hash === expectedHash) {
+          return;
+        }
+        const baseUrl = `${window.location.pathname}${window.location.search || ''}`;
+        window.history.replaceState(null, '', `${baseUrl}${expectedHash}`);
+      }
+
+      function remapDomIds(baseId, targetId) {
+        if (!baseId || !targetId || baseId === targetId) {
+          return baseId;
+        }
+        const basePrefix = `${baseId}-`;
+        const targetPrefix = `${targetId}-`;
+        document.querySelectorAll(`[id^="${baseId}"]`).forEach((el) => {
+          if (el.id === baseId) {
+            el.id = targetId;
+          } else if (el.id.startsWith(basePrefix)) {
+            el.id = `${targetPrefix}${el.id.slice(basePrefix.length)}`;
+          }
+        });
+        document.querySelectorAll(`[for^="${baseId}"]`).forEach((label) => {
+          const current = label.getAttribute('for');
+          if (!current) {
+            return;
+          }
+          if (current === baseId) {
+            label.setAttribute('for', targetId);
+          } else if (current.startsWith(basePrefix)) {
+            label.setAttribute('for', `${targetPrefix}${current.slice(basePrefix.length)}`);
+          }
+        });
+        return targetId;
+      }
+
+      function updateRowLabel(cellId) {
+        const row = document.querySelector('.cam-row');
+        if (!row) {
+          return;
+        }
+        const match = /^cam(\d+)$/i.exec(cellId);
+        if (match) {
+          row.dataset.rowLabel = `สตรีม ${match[1]}`;
+        }
+      }
+
+      const requestedCellId = resolveCellId(DEFAULT_CELL_ID);
+      const cellId = remapDomIds(DEFAULT_CELL_ID, requestedCellId) || DEFAULT_CELL_ID;
+      updateRowLabel(cellId);
+      ensureLocationHash(cellId);
+
       function initRoiLayout(cellId) {
         const videoCell = document.getElementById(cellId);
         const videoCol = videoCell ? videoCell.closest('.video-col') : null;
@@ -734,9 +801,9 @@
     }
 
   // initialize controllers immediately (DOMContentLoaded already fired in fragments)
-  ['cam1'].forEach(initRoiLayout);
+  [cellId].forEach(initRoiLayout);
   const controllers = [
-      createCameraController('cam1')
+      createCameraController(cellId)
   ];
-  })();
+      })();
   </script>

--- a/templates/partials/inference_content.html
+++ b/templates/partials/inference_content.html
@@ -114,6 +114,10 @@
         let allRois = [];
         let running = false;
         const cam = `inf_${cellId}`;
+        const sessionRegistry = window.InferenceSessions;
+        const camRoot = document.getElementById(cellId);
+        const camRow = camRoot ? camRoot.closest('.cam-row') : null;
+        const sessionTitle = camRow && camRow.dataset.rowLabel ? camRow.dataset.rowLabel : cellId;
         const getEl = suffix => document.getElementById(`${cellId}-${suffix}`);
         const video = getEl('video');
         const videoCtx = video.getContext('2d');
@@ -316,6 +320,11 @@
                         : fallbackFrameTime;
                     timeEl.textContent = ts ? `เวลา: ${formatTs(ts)}` : '';
                 }
+            }
+            if (sessionRegistry && typeof sessionRegistry.updateSession === 'function') {
+                sessionRegistry.updateSession(cam, {
+                    status: 'running'
+                });
             }
         }
 
@@ -561,6 +570,20 @@
             }
             startLogUpdates(cfg.name);
             setRunningUI();
+            const sourceOption = sourceSelect.options[sourceSelect.selectedIndex];
+            const groupLabel = groupToUse === 'all' ? 'ทั้งหมด (All ROI)' : groupToUse;
+            if (sessionRegistry && typeof sessionRegistry.upsertSession === 'function') {
+                sessionRegistry.upsertSession({
+                    id: cam,
+                    type: 'group',
+                    title: sessionTitle,
+                    sourceId: sourceSelect.value || '',
+                    sourceName: sourceOption ? sourceOption.textContent : '',
+                    group: groupLabel || '',
+                    href: `/inference/group#${cellId}`,
+                    status: 'running'
+                });
+            }
         }
 
         async function stopInference() {
@@ -598,6 +621,11 @@
             storeGroupSelection('');
             updateLogRoiOptions([]);
             showAlert('Inference stopped', 'info');
+            if (sessionRegistry && typeof sessionRegistry.updateSession === 'function') {
+                sessionRegistry.updateSession(cam, {
+                    status: 'stopped'
+                });
+            }
         }
 
         function openSocket() {
@@ -701,6 +729,12 @@
         async function switchGroup() {
             const selected = groupSelect.value;
             storeGroupSelection(selected);
+            if (sessionRegistry && typeof sessionRegistry.updateSession === 'function') {
+                const label = selected === 'all' ? 'ทั้งหมด (All ROI)' : selected;
+                sessionRegistry.updateSession(cam, {
+                    group: label || ''
+                });
+            }
             if (!selected) {
                 updateLogRoiOptions([]);
                 return;

--- a/templates/partials/inference_content.html
+++ b/templates/partials/inference_content.html
@@ -1,3 +1,8 @@
+{% set current_session_id = session_id or '' %}
+{% set base_cam_id = current_session_id if current_session_id else 'cam-template' %}
+{% set session_base = url_for('inference_group_template').rstrip('/') ~ '/' %}
+{% set default_row_label = ('สตรีม ' ~ current_session_id[3:]) if current_session_id and current_session_id.startswith('cam') else (current_session_id or 'สตรีมใหม่') %}
+<div class="inference-session-root" data-session-root data-template-mode="{{ 'true' if not current_session_id else 'false' }}" data-session-id="{{ current_session_id }}" data-default-cell-id="{{ base_cam_id }}" data-session-base="{{ session_base }}">
 <div class="inference-session-toolbar card shadow-sm mb-4">
     <div class="inference-session-toolbar__body">
         <div class="inference-session-toolbar__info">
@@ -7,82 +12,75 @@
         <div class="inference-session-toolbar__actions">
             <span class="badge bg-primary-subtle text-primary inference-session-toolbar__badge">
                 <i class="bi bi-hash me-1"></i><span>Cam ปัจจุบัน:</span>
-                <strong class="ms-1" data-current-session-id>cam1</strong>
+                <strong class="ms-1" data-current-session-id>{{ current_session_id or '—' }}</strong>
             </span>
             <a href="{{ url_for('inference_hub') }}" class="btn btn-outline-secondary">
                 <i class="bi bi-arrow-left-circle me-1"></i>กลับหน้า Inference Hub
             </a>
-            <button type="button" class="btn btn-primary" data-action="create-new-session" data-base-href="{{ url_for('inference_group') }}">
+            <button type="button" class="btn btn-primary" data-action="create-new-session" data-base-href="{{ url_for('inference_group_template') }}">
                 <i class="bi bi-plus-circle me-1"></i>สร้างหน้าใหม่
             </button>
         </div>
     </div>
 </div>
 
-<div class="cam-row" data-row-label="สตรีม 1">
+<div class="cam-row" data-row-label="{{ default_row_label }}">
     <div class="video-col">
         <div class="card roi-card video-card">
-            <div id="cam1" class="cam-cell">
+            <div id="{{ base_cam_id }}" class="cam-cell">
                 <div class="d-flex align-items-center mb-2 gap-2 menu-select-list flex-wrap">
-                    <label for="cam1-sourceSelect" class="form-label mb-0">Source:</label>
-                    <select id="cam1-sourceSelect" class="form-select w-auto"></select>
-                    <label for="cam1-intervalInput" class="form-label mb-0">Time (interval):</label>
-                    <input id="cam1-intervalInput" type="number" class="form-control w-auto" min="0" step="0.1" value="1" />
-                    <label for="cam1-groupSelect" class="form-label mb-0">Group:</label>
-                    <select id="cam1-groupSelect" class="form-select w-auto flex-grow-1" style="min-width:0;"></select>
+                    <label for="{{ base_cam_id }}-sourceSelect" class="form-label mb-0">Source:</label>
+                    <select id="{{ base_cam_id }}-sourceSelect" class="form-select w-auto"></select>
+                    <label for="{{ base_cam_id }}-intervalInput" class="form-label mb-0">Time (interval):</label>
+                    <input id="{{ base_cam_id }}-intervalInput" type="number" class="form-control w-auto" min="0" step="0.1" value="1" />
+                    <label for="{{ base_cam_id }}-groupSelect" class="form-label mb-0">Group:</label>
+                    <select id="{{ base_cam_id }}-groupSelect" class="form-select w-auto flex-grow-1" style="min-width:0;"></select>
                 </div>
-                <button id="cam1-startButton" class="btn btn-primary me-2">Start</button>
-                <button id="cam1-stopButton" class="btn btn-danger" disabled>Stop</button>
-                <p id="cam1-status"></p>
+                <button id="{{ base_cam_id }}-startButton" class="btn btn-primary me-2">Start</button>
+                <button id="{{ base_cam_id }}-stopButton" class="btn btn-danger" disabled>Stop</button>
+                <p id="{{ base_cam_id }}-status"></p>
                 <div class="video-wrapper">
-                    <canvas id="cam1-video" class="stream-video"></canvas>
+                    <canvas id="{{ base_cam_id }}-video" class="stream-video"></canvas>
                 </div>
             </div>
         </div>
         <div class="card roi-card log-card">
             <div class="d-flex align-items-center mb-2 gap-2 menu-select-list">
-                <label for="cam1-logRoiSelect" class="form-label mb-0">ROI:</label>
-                <select id="cam1-logRoiSelect" class="form-select w-auto"></select>
+                <label for="{{ base_cam_id }}-logRoiSelect" class="form-label mb-0">ROI:</label>
+                <select id="{{ base_cam_id }}-logRoiSelect" class="form-select w-auto"></select>
             </div>
             <div class="log-wrapper">
-                <table id="cam1-logTable" class="table table-striped">
+                <table id="{{ base_cam_id }}-logTable" class="table table-striped">
                     <thead><tr><th>Log</th></tr></thead>
-                    <tbody id="cam1-logBody"></tbody>
+                    <tbody id="{{ base_cam_id }}-logBody"></tbody>
                 </table>
             </div>
         </div>
     </div>
     <div class="card roi-card roi-list-card">
-        <div id="cam1-rois" class="roi-grid"></div>
+        <div id="{{ base_cam_id }}-rois" class="roi-grid"></div>
     </div>
 </div>
 
   <script>
       (function() {
-      const DEFAULT_CELL_ID = 'cam1';
+      const DEFAULT_CELL_ID = '{{ base_cam_id }}';
       const sessionRegistry = window.InferenceSessions;
 
-      function resolveCellId(defaultId) {
-        const raw = String(window.location.hash || '').replace(/^#/, '').trim();
-        if (!raw) {
-          return defaultId;
+      const root = document.querySelector('[data-session-root]');
+      const sessionIndicator = document.querySelector('[data-current-session-id]');
+
+      function ensureTrailingSlash(value) {
+        if (!value) {
+          return '/inference/group/';
         }
-        const match = /^cam(\d+)$/i.exec(raw);
-        if (!match) {
-          return defaultId;
-        }
-        const num = parseInt(match[1], 10);
-        return Number.isFinite(num) && num > 0 ? `cam${num}` : defaultId;
+        return value.endsWith('/') ? value : `${value}/`;
       }
 
-      function ensureLocationHash(cellId) {
-        const expectedHash = `#${cellId}`;
-        if (window.location.hash === expectedHash) {
-          return;
-        }
-        const baseUrl = `${window.location.pathname}${window.location.search || ''}`;
-        window.history.replaceState(null, '', `${baseUrl}${expectedHash}`);
-      }
+      const sessionBase = ensureTrailingSlash(root?.dataset.sessionBase || '/inference/group');
+      const placeholderId = root?.dataset.defaultCellId || DEFAULT_CELL_ID;
+      let cellId = placeholderId;
+      let templateMode = root?.dataset.templateMode === 'true';
 
       function remapDomIds(baseId, targetId) {
         if (!baseId || !targetId || baseId === targetId) {
@@ -117,18 +115,11 @@
           return;
         }
         const match = /^cam(\d+)$/i.exec(cellId);
-        if (match) {
-          row.dataset.rowLabel = `สตรีม ${match[1]}`;
-        }
+        row.dataset.rowLabel = match ? `สตรีม ${match[1]}` : 'สตรีมใหม่';
       }
 
-      const requestedCellId = resolveCellId(DEFAULT_CELL_ID);
-      const cellId = remapDomIds(DEFAULT_CELL_ID, requestedCellId) || DEFAULT_CELL_ID;
       updateRowLabel(cellId);
-      ensureLocationHash(cellId);
-
-      const sessionIndicator = document.querySelector('[data-current-session-id]');
-      if (sessionIndicator) {
+      if (!templateMode && sessionIndicator) {
         sessionIndicator.textContent = cellId;
       }
 
@@ -161,22 +152,73 @@
         return fallbackNextCamId(cellId);
       }
 
-      function buildTargetHref(baseHref, cam) {
-        const href = typeof baseHref === 'string' && baseHref.length > 0 ? baseHref : window.location.pathname;
-        const hashIndex = href.indexOf('#');
-        const cleanBase = hashIndex > -1 ? href.slice(0, hashIndex) : href;
-        return `${cleanBase}#${cam}`;
+      function buildSessionHref(cam) {
+        return `${sessionBase}${cam}`;
+      }
+
+      function replaceUrlWithSession(cam) {
+        const target = buildSessionHref(cam);
+        const query = window.location.search || '';
+        if (window.location.pathname !== target || window.location.hash) {
+          window.history.replaceState(null, '', `${target}${query}`);
+        }
+      }
+
+      function migratePersistedValues(fromId, toId) {
+        const suffixes = ['source', 'interval', 'group'];
+        suffixes.forEach((suffix) => {
+          const fromKey = `${fromId}-${suffix}`;
+          const value = localStorage.getItem(fromKey);
+          if (value !== null) {
+            const toKey = `${toId}-${suffix}`;
+            try {
+              localStorage.setItem(toKey, value);
+            } catch (err) {
+              console.warn('ไม่สามารถย้ายข้อมูลการตั้งค่าได้', err);
+            }
+            localStorage.removeItem(fromKey);
+          }
+        });
+      }
+
+      function applySessionId(newId) {
+        cellId = newId;
+        updateRowLabel(cellId);
+        if (sessionIndicator) {
+          sessionIndicator.textContent = cellId;
+        }
+        if (root) {
+          root.dataset.sessionId = cellId;
+        }
+        return cellId;
+      }
+
+      function promoteTemplateSession() {
+        if (!templateMode) {
+          return cellId;
+        }
+        const nextCam = computeNextCamId();
+        const newCellId = remapDomIds(placeholderId, nextCam) || nextCam;
+        migratePersistedValues(placeholderId, newCellId);
+        templateMode = false;
+        if (root) {
+          root.dataset.templateMode = 'false';
+        }
+        applySessionId(newCellId);
+        return cellId;
       }
 
       document.querySelectorAll('[data-action="create-new-session"]').forEach((button) => {
         button.addEventListener('click', (event) => {
           event.preventDefault();
-          const baseHref = button.getAttribute('data-base-href') || window.location.pathname;
-          const nextCam = computeNextCamId();
-          const target = buildTargetHref(baseHref, nextCam);
-          window.location.href = target;
+          const baseHref = button.getAttribute('data-base-href') || '/inference/group';
+          window.location.href = baseHref;
         });
       });
+
+      if (!templateMode) {
+        replaceUrlWithSession(cellId);
+      }
 
       function initRoiLayout(cellId) {
         const videoCell = document.getElementById(cellId);
@@ -209,16 +251,16 @@
         window.addEventListener('resize', updateHeight);
       }
 
-      function createCameraController(cellId) {
+      function createCameraController() {
         let socket;
         let roiSocket;
         let rois = [];
         let allRois = [];
         let running = false;
-        const cam = `inf_${cellId}`;
+        let cam = `inf_${cellId}`;
         const camRoot = document.getElementById(cellId);
         const camRow = camRoot ? camRoot.closest('.cam-row') : null;
-        const sessionTitle = camRow && camRow.dataset.rowLabel ? camRow.dataset.rowLabel : cellId;
+        let sessionTitle = camRow && camRow.dataset.rowLabel ? camRow.dataset.rowLabel : cellId;
         const getEl = suffix => document.getElementById(`${cellId}-${suffix}`);
         const video = getEl('video');
         const videoCtx = video.getContext('2d');
@@ -235,18 +277,37 @@
         let isLogUpdating = false;
         let logSessionId = 0;
         let currentLogSource;
-        intervalInput.value = localStorage.getItem(`${cellId}-interval`) || '1';
-        const groupStorageKey = `${cellId}-group`;
+        const getStorageKey = (suffix) => `${cellId}-${suffix}`;
+        intervalInput.value = localStorage.getItem(getStorageKey('interval')) || '1';
         let lastActiveGroup = '';
-
-        const getStoredGroup = () => localStorage.getItem(groupStorageKey) || '';
+        const getStoredGroup = () => localStorage.getItem(getStorageKey('group')) || '';
         const storeGroupSelection = value => {
             if (value) {
-                localStorage.setItem(groupStorageKey, value);
+                localStorage.setItem(getStorageKey('group'), value);
             } else {
-                localStorage.removeItem(groupStorageKey);
+                localStorage.removeItem(getStorageKey('group'));
             }
         };
+
+        function syncSessionMetadata() {
+            sessionTitle = camRow && camRow.dataset.rowLabel ? camRow.dataset.rowLabel : cellId;
+            cam = `inf_${cellId}`;
+        }
+
+        function restorePersistedSelections() {
+            const storedInterval = localStorage.getItem(getStorageKey('interval'));
+            if (storedInterval !== null) {
+                intervalInput.value = storedInterval;
+            }
+            const storedSource = localStorage.getItem(getStorageKey('source'));
+            if (storedSource && sourceSelect.options.length) {
+                sourceSelect.value = storedSource;
+            }
+            lastActiveGroup = getStoredGroup();
+            if (lastActiveGroup && groupSelect.options.length) {
+                groupSelect.value = lastActiveGroup;
+            }
+        }
 
         const formatTs = ts => {
             if (!ts) return '';
@@ -267,7 +328,7 @@
         };
 
         sourceSelect.onchange = () => {
-            localStorage.setItem(`${cellId}-source`, sourceSelect.value);
+            localStorage.setItem(getStorageKey('source'), sourceSelect.value);
         };
 
         startButton.onclick = startInference;
@@ -278,6 +339,10 @@
                 startLogUpdates(currentLogSource);
             }
         };
+
+        if (!templateMode) {
+            restorePersistedSelections();
+        }
 
         async function fetchWithStatus(url, options = {}) {
             statusEl.innerText = 'กำลังโหลด...';
@@ -312,7 +377,7 @@
                         opt.textContent = item.name;
                         sourceSelect.appendChild(opt);
                     });
-                    const stored = localStorage.getItem(`${cellId}-source`) || '';
+                    const stored = localStorage.getItem(getStorageKey('source')) || '';
                     if (stored) {
                         sourceSelect.value = stored;
                     }
@@ -574,6 +639,12 @@
             if (running) return;
             running = true;
             startButton.disabled = true;
+            const previousId = cellId;
+            const assignedId = promoteTemplateSession();
+            if (assignedId !== previousId) {
+                syncSessionMetadata();
+                restorePersistedSelections();
+            }
             const name = sourceSelect.value;
             if (!name) {
                 statusEl.innerText = 'Select source first';
@@ -582,14 +653,14 @@
                 showAlert('Select source first', 'error');
                 return;
             }
-            localStorage.setItem(`${cellId}-source`, name);
+            localStorage.setItem(getStorageKey('source'), name);
 
             const cfgRes = await fetchWithStatus(`/source_config?name=${encodeURIComponent(name)}`);
             const cfg = await cfgRes.json();
 
             const { module: _unused, rois: roiPathRaw, ...camCfg } = cfg;
             const interval = parseFloat(intervalInput.value) || 1;
-            localStorage.setItem(`${cellId}-interval`, interval);
+            localStorage.setItem(getStorageKey('interval'), interval);
             let roiPath = roiPathRaw;
             if (!roiPath.startsWith('/')) {
                 roiPath = `data_sources/${cfg.name}/${roiPath}`;
@@ -673,6 +744,7 @@
             setRunningUI();
             const sourceOption = sourceSelect.options[sourceSelect.selectedIndex];
             const groupLabel = groupToUse === 'all' ? 'ทั้งหมด (All ROI)' : groupToUse;
+            replaceUrlWithSession(cellId);
             if (sessionRegistry && typeof sessionRegistry.upsertSession === 'function') {
                 sessionRegistry.upsertSession({
                     id: cam,
@@ -681,7 +753,7 @@
                     sourceId: sourceSelect.value || '',
                     sourceName: sourceOption ? sourceOption.textContent : '',
                     group: groupLabel || '',
-                    href: `/inference/group#${cellId}`,
+                    href: buildSessionHref(cellId),
                     status: 'running'
                 });
             }
@@ -872,9 +944,10 @@
     }
 
   // initialize controllers immediately (DOMContentLoaded already fired in fragments)
-  [cellId].forEach(initRoiLayout);
+  initRoiLayout(cellId);
   const controllers = [
-      createCameraController(cellId)
+      createCameraController()
   ];
       })();
   </script>
+</div>

--- a/templates/partials/inference_content.html
+++ b/templates/partials/inference_content.html
@@ -37,43 +37,6 @@
     </div>
 </div>
 
-<div class="cam-row mt-4" data-row-label="สตรีม 2">
-    <div class="video-col">
-        <div class="card roi-card video-card">
-            <div id="cam2" class="cam-cell">
-                <div class="d-flex align-items-center mb-2 gap-2 menu-select-list flex-wrap">
-                    <label for="cam2-sourceSelect" class="form-label mb-0">Source:</label>
-                    <select id="cam2-sourceSelect" class="form-select w-auto"></select>
-                    <label for="cam2-intervalInput" class="form-label mb-0">Time (interval):</label>
-                    <input id="cam2-intervalInput" type="number" class="form-control w-auto" min="0" step="0.1" value="1" />
-                    <label for="cam2-groupSelect" class="form-label mb-0">Group:</label>
-                    <select id="cam2-groupSelect" class="form-select w-auto flex-grow-1" style="min-width:0;"></select>
-                </div>
-                <button id="cam2-startButton" class="btn btn-primary me-2">Start</button>
-                <button id="cam2-stopButton" class="btn btn-danger" disabled>Stop</button>
-                <p id="cam2-status"></p>
-                <div class="video-wrapper">
-                    <canvas id="cam2-video" class="stream-video"></canvas>
-                </div>
-            </div>
-        </div>
-        <div class="card roi-card log-card">
-            <div class="d-flex align-items-center mb-2 gap-2 menu-select-list">
-                <label for="cam2-logRoiSelect" class="form-label mb-0">ROI:</label>
-                <select id="cam2-logRoiSelect" class="form-select w-auto"></select>
-            </div>
-            <div class="log-wrapper">
-                <table id="cam2-logTable" class="table table-striped">
-                    <thead><tr><th>Log</th></tr></thead>
-                    <tbody id="cam2-logBody"></tbody>
-                </table>
-            </div>
-        </div>
-    </div>
-    <div class="card roi-card roi-list-card">
-        <div id="cam2-rois" class="roi-grid"></div>
-    </div>
-</div>
   <script>
       (function() {
       function initRoiLayout(cellId) {
@@ -771,10 +734,9 @@
     }
 
   // initialize controllers immediately (DOMContentLoaded already fired in fragments)
-  ['cam1', 'cam2'].forEach(initRoiLayout);
+  ['cam1'].forEach(initRoiLayout);
   const controllers = [
-      createCameraController('cam1'),
-      createCameraController('cam2')
+      createCameraController('cam1')
   ];
   })();
   </script>

--- a/templates/partials/inference_content.html
+++ b/templates/partials/inference_content.html
@@ -1,3 +1,23 @@
+<div class="inference-session-toolbar card shadow-sm mb-4">
+    <div class="inference-session-toolbar__body">
+        <div class="inference-session-toolbar__info">
+            <h1 class="inference-session-toolbar__title">Group Inference</h1>
+            <p class="inference-session-toolbar__subtitle">สร้างหลายหน้าด้วยรหัส cam1, cam2, ... เพื่อจัดการสตรีมแบบแยกหน้า</p>
+        </div>
+        <div class="inference-session-toolbar__actions">
+            <span class="badge bg-primary-subtle text-primary inference-session-toolbar__badge">
+                <i class="bi bi-hash me-1"></i><span>Cam ปัจจุบัน:</span>
+                <strong class="ms-1" data-current-session-id>cam1</strong>
+            </span>
+            <a href="{{ url_for('inference_hub') }}" class="btn btn-outline-secondary">
+                <i class="bi bi-arrow-left-circle me-1"></i>กลับหน้า Inference Hub
+            </a>
+            <button type="button" class="btn btn-primary" data-action="create-new-session" data-base-href="{{ url_for('inference_group') }}">
+                <i class="bi bi-plus-circle me-1"></i>สร้างหน้าใหม่
+            </button>
+        </div>
+    </div>
+</div>
 
 <div class="cam-row" data-row-label="สตรีม 1">
     <div class="video-col">
@@ -40,6 +60,7 @@
   <script>
       (function() {
       const DEFAULT_CELL_ID = 'cam1';
+      const sessionRegistry = window.InferenceSessions;
 
       function resolveCellId(defaultId) {
         const raw = String(window.location.hash || '').replace(/^#/, '').trim();
@@ -106,6 +127,57 @@
       updateRowLabel(cellId);
       ensureLocationHash(cellId);
 
+      const sessionIndicator = document.querySelector('[data-current-session-id]');
+      if (sessionIndicator) {
+        sessionIndicator.textContent = cellId;
+      }
+
+      function fallbackNextCamId(currentId) {
+        const match = /^cam(\d+)$/i.exec(currentId || '');
+        if (!match) {
+          return 'cam2';
+        }
+        const nextIndex = parseInt(match[1], 10) + 1;
+        return `cam${Number.isFinite(nextIndex) && nextIndex > 0 ? nextIndex : 2}`;
+      }
+
+      function computeNextCamId() {
+        if (sessionRegistry && typeof sessionRegistry.getNextCamId === 'function') {
+          try {
+            const next = sessionRegistry.getNextCamId();
+            if (typeof next === 'string' && next) {
+              return next;
+            }
+            if (next && typeof next.id === 'string' && next.id) {
+              return next.id;
+            }
+            if (next && typeof next.index === 'number' && next.index > 0) {
+              return `cam${next.index}`;
+            }
+          } catch (err) {
+            console.warn('ไม่สามารถอ่านหมายเลข cam ถัดไปจากรีจิสทรีได้', err);
+          }
+        }
+        return fallbackNextCamId(cellId);
+      }
+
+      function buildTargetHref(baseHref, cam) {
+        const href = typeof baseHref === 'string' && baseHref.length > 0 ? baseHref : window.location.pathname;
+        const hashIndex = href.indexOf('#');
+        const cleanBase = hashIndex > -1 ? href.slice(0, hashIndex) : href;
+        return `${cleanBase}#${cam}`;
+      }
+
+      document.querySelectorAll('[data-action="create-new-session"]').forEach((button) => {
+        button.addEventListener('click', (event) => {
+          event.preventDefault();
+          const baseHref = button.getAttribute('data-base-href') || window.location.pathname;
+          const nextCam = computeNextCamId();
+          const target = buildTargetHref(baseHref, nextCam);
+          window.location.href = target;
+        });
+      });
+
       function initRoiLayout(cellId) {
         const videoCell = document.getElementById(cellId);
         const videoCol = videoCell ? videoCell.closest('.video-col') : null;
@@ -144,7 +216,6 @@
         let allRois = [];
         let running = false;
         const cam = `inf_${cellId}`;
-        const sessionRegistry = window.InferenceSessions;
         const camRoot = document.getElementById(cellId);
         const camRow = camRoot ? camRoot.closest('.cam-row') : null;
         const sessionTitle = camRow && camRow.dataset.rowLabel ? camRow.dataset.rowLabel : cellId;

--- a/templates/partials/inference_page_content.html
+++ b/templates/partials/inference_page_content.html
@@ -41,6 +41,73 @@
 </div>
 <script>
 (function(){
+const DEFAULT_CELL_ID='cam1';
+
+function resolveCellId(defaultId){
+    const raw=String(window.location.hash||'').replace(/^#/,'').trim();
+    if(!raw){
+        return defaultId;
+    }
+    const match=/^cam(\d+)$/i.exec(raw);
+    if(!match){
+        return defaultId;
+    }
+    const num=parseInt(match[1],10);
+    return Number.isFinite(num)&&num>0?`cam${num}`:defaultId;
+}
+
+function ensureLocationHash(cellId){
+    const expected=`#${cellId}`;
+    if(window.location.hash===expected){
+        return;
+    }
+    const baseUrl=`${window.location.pathname}${window.location.search||''}`;
+    window.history.replaceState(null,'',`${baseUrl}${expected}`);
+}
+
+function remapDomIds(baseId,targetId){
+    if(!baseId||!targetId||baseId===targetId){
+        return baseId;
+    }
+    const basePrefix=`${baseId}-`;
+    const targetPrefix=`${targetId}-`;
+    document.querySelectorAll(`[id^="${baseId}"]`).forEach(el=>{
+        if(el.id===baseId){
+            el.id=targetId;
+        }else if(el.id.startsWith(basePrefix)){
+            el.id=`${targetPrefix}${el.id.slice(basePrefix.length)}`;
+        }
+    });
+    document.querySelectorAll(`[for^="${baseId}"]`).forEach(label=>{
+        const current=label.getAttribute('for');
+        if(!current){
+            return;
+        }
+        if(current===baseId){
+            label.setAttribute('for',targetId);
+        }else if(current.startsWith(basePrefix)){
+            label.setAttribute('for',`${targetPrefix}${current.slice(basePrefix.length)}`);
+        }
+    });
+    return targetId;
+}
+
+function updateRowLabel(cellId){
+    const row=document.querySelector('.cam-row');
+    if(!row){
+        return;
+    }
+    const match=/^cam(\d+)$/i.exec(cellId);
+    if(match){
+        row.dataset.rowLabel=`สตรีม ${match[1]}`;
+    }
+}
+
+const requestedCellId=resolveCellId(DEFAULT_CELL_ID);
+const cellId=remapDomIds(DEFAULT_CELL_ID,requestedCellId)||DEFAULT_CELL_ID;
+updateRowLabel(cellId);
+ensureLocationHash(cellId);
+
 function initRoiLayout(cellId){
     const videoCell=document.getElementById(cellId);
     const videoCol=videoCell?videoCell.closest('.video-col'):null;
@@ -621,10 +688,8 @@ function createController(cellId){
         await checkStatus();
     })();
 }
-document.addEventListener('DOMContentLoaded',()=>{
-    initRoiLayout('cam1');
-    createController('cam1');
-});
+initRoiLayout(cellId);
+createController(cellId);
 })();
 </script>
 

--- a/templates/partials/inference_page_content.html
+++ b/templates/partials/inference_page_content.html
@@ -71,6 +71,10 @@ function createController(cellId){
     let roiSocket;
     let running=false;
     const cam=`page_${cellId}`;
+    const sessionRegistry=window.InferenceSessions;
+    const camRoot=document.getElementById(cellId);
+    const camRow=camRoot?camRoot.closest('.cam-row'):null;
+    const sessionTitle=camRow&&camRow.dataset.rowLabel?camRow.dataset.rowLabel:cellId;
     const getEl=suffix=>document.getElementById(`${cellId}-${suffix}`);
     const video=getEl('video');
     const videoCtx=video.getContext('2d');
@@ -249,6 +253,19 @@ function createController(cellId){
         setRunningUI();
         startLogUpdates(cfg.name);
         showAlert('Stream started','success');
+        const sourceOption=sourceSelect.options[sourceSelect.selectedIndex];
+        if(sessionRegistry&&typeof sessionRegistry.upsertSession==='function'){
+            sessionRegistry.upsertSession({
+                id:cam,
+                type:'page',
+                title:sessionTitle,
+                sourceId:sourceSelect.value||'',
+                sourceName:sourceOption?sourceOption.textContent:'',
+                page:pageNameEl?pageNameEl.textContent:'',
+                href:`/inference/page#${cellId}`,
+                status:'running'
+            });
+        }
         }
 
 
@@ -278,6 +295,12 @@ function createController(cellId){
                 if('group' in data){
                     setTimeout(()=>{
                         pageNameEl.innerText=data.group||'';
+                        if(sessionRegistry&&typeof sessionRegistry.updateSession==='function'){
+                            sessionRegistry.updateSession(cam,{
+                                page:data.group||'',
+                                status:'running'
+                            });
+                        }
                         if(Array.isArray(data.scores)){
                             scoreTableBody.innerHTML='';
                             data.scores.forEach(item=>{
@@ -537,6 +560,12 @@ function createController(cellId){
         stopButton.disabled=true;
         statusEl.innerText='Stopped';
         showAlert('Stream stopped','info');
+        if(sessionRegistry&&typeof sessionRegistry.updateSession==='function'){
+            sessionRegistry.updateSession(cam,{
+                status:'stopped',
+                page:''
+            });
+        }
     }
 
     function setRunningUI(){

--- a/templates/partials/inference_page_content.html
+++ b/templates/partials/inference_page_content.html
@@ -1,3 +1,8 @@
+{% set current_session_id = session_id or '' %}
+{% set base_cam_id = current_session_id if current_session_id else 'cam1' %}
+{% set session_base = url_for('inference_page_template').rstrip('/') ~ '/' %}
+{% set default_row_label = ('สตรีม ' ~ current_session_id[3:]) if current_session_id and current_session_id.startswith('cam') else 'สตรีม 1' %}
+<div class="inference-session-root" data-session-root data-template-mode="{{ 'true' if not current_session_id else 'false' }}" data-session-id="{{ current_session_id }}" data-default-cell-id="{{ base_cam_id }}" data-session-base="{{ session_base }}">
 <div class="inference-session-toolbar card shadow-sm mb-4">
     <div class="inference-session-toolbar__body">
         <div class="inference-session-toolbar__info">
@@ -7,74 +12,92 @@
         <div class="inference-session-toolbar__actions">
             <span class="badge bg-info-subtle text-info inference-session-toolbar__badge">
                 <i class="bi bi-hash me-1"></i><span>Cam ปัจจุบัน:</span>
-                <strong class="ms-1" data-current-session-id>cam1</strong>
+                <strong class="ms-1" data-current-session-id>{{ current_session_id or '—' }}</strong>
             </span>
             <a href="{{ url_for('inference_hub') }}" class="btn btn-outline-secondary">
                 <i class="bi bi-arrow-left-circle me-1"></i>กลับหน้า Inference Hub
             </a>
-            <button type="button" class="btn btn-info text-white" data-action="create-new-session" data-base-href="{{ url_for('inference_page_alias') }}">
+            <button type="button" class="btn btn-info text-white" data-action="create-new-session" data-base-href="{{ url_for('inference_page_template') }}">
                 <i class="bi bi-plus-circle me-1"></i>สร้างหน้าใหม่
             </button>
         </div>
     </div>
 </div>
 
-<div class="cam-row" data-row-label="สตรีม 1">
+<div class="cam-row" data-row-label="{{ default_row_label }}">
     <div class="video-col">
         <div class="card roi-card video-card">
-            <div id="cam1" class="cam-cell">
+            <div id="{{ base_cam_id }}" class="cam-cell">
             <div class="d-flex align-items-center mb-2 gap-2 menu-select-list">
-                <label for="cam1-sourceSelect" class="form-label mb-0">Source:</label>
-                <select id="cam1-sourceSelect" class="form-select w-auto"></select>
-                <label for="cam1-intervalInput" class="form-label mb-0">Time:</label>
-                <input id="cam1-intervalInput" type="number" class="form-control w-auto" min="0" step="0.1" value="1" />
+                <label for="{{ base_cam_id }}-sourceSelect" class="form-label mb-0">Source:</label>
+                <select id="{{ base_cam_id }}-sourceSelect" class="form-select w-auto"></select>
+                <label for="{{ base_cam_id }}-intervalInput" class="form-label mb-0">Time:</label>
+                <input id="{{ base_cam_id }}-intervalInput" type="number" class="form-control w-auto" min="0" step="0.1" value="1" />
             </div>
-            <button id="cam1-startButton" class="btn btn-primary me-2">Start</button>
-            <button id="cam1-stopButton" class="btn btn-danger" disabled>Stop</button>
-            <p id="cam1-status"></p>
+            <button id="{{ base_cam_id }}-startButton" class="btn btn-primary me-2">Start</button>
+            <button id="{{ base_cam_id }}-stopButton" class="btn btn-danger" disabled>Stop</button>
+            <p id="{{ base_cam_id }}-status"></p>
             <div class="video-wrapper">
-                <canvas id="cam1-video" class="stream-video"></canvas>
-                <p>page: <span id="cam1-pageName"></span></p>
-                <table id="cam1-pageScores" class="table table-striped">
+                <canvas id="{{ base_cam_id }}-video" class="stream-video"></canvas>
+                <p>page: <span id="{{ base_cam_id }}-pageName"></span></p>
+                <table id="{{ base_cam_id }}-pageScores" class="table table-striped">
                     <thead><tr><th>Page</th><th>Score</th></tr></thead>
-                    <tbody id="cam1-pageScoresBody"></tbody>
+                    <tbody id="{{ base_cam_id }}-pageScoresBody"></tbody>
                 </table>
             </div>
             </div>
         </div>
         <div class="card roi-card log-card">
             <div class="d-flex align-items-center mb-2 gap-2">
-                <label for="cam1-logRoiSelect" class="form-label mb-0">ROI:</label>
-                <select id="cam1-logRoiSelect" class="form-select w-auto"></select>
+                <label for="{{ base_cam_id }}-logRoiSelect" class="form-label mb-0">ROI:</label>
+                <select id="{{ base_cam_id }}-logRoiSelect" class="form-select w-auto"></select>
             </div>
             <div class="log-wrapper">
-                <table id="cam1-logTable" class="table table-striped">
+                <table id="{{ base_cam_id }}-logTable" class="table table-striped">
                     <thead><tr><th>Log</th></tr></thead>
-                    <tbody id="cam1-logBody"></tbody>
+                    <tbody id="{{ base_cam_id }}-logBody"></tbody>
                 </table>
             </div>
         </div>
     </div>
     <div class="card roi-card roi-list-card">
-        <div id="cam1-rois" class="roi-grid"></div>
+        <div id="{{ base_cam_id }}-rois" class="roi-grid"></div>
     </div>
+</div>
 </div>
 <script>
 (function(){
-const DEFAULT_CELL_ID='cam1';
 const sessionRegistry=window.InferenceSessions;
+const root=document.querySelector('[data-session-root]');
+const DEFAULT_CELL_ID='{{ base_cam_id }}';
+const placeholderId=root?.dataset.defaultCellId||DEFAULT_CELL_ID;
+const sessionIndicator=root?root.querySelector('[data-current-session-id]'):document.querySelector('[data-current-session-id]');
+
+function ensureTrailingSlash(value){
+    if(!value){
+        return'/inference/page/';
+    }
+    return value.endsWith('/')?value:`${value}/`;
+}
+
+const sessionBase=ensureTrailingSlash(root?.dataset.sessionBase||'/inference/page');
 
 function resolveCellId(defaultId){
     const raw=String(window.location.hash||'').replace(/^#/,'').trim();
-    if(!raw){
-        return defaultId;
+    if(raw){
+        const match=/^cam(\d+)$/i.exec(raw);
+        if(match){
+            const num=parseInt(match[1],10);
+            if(Number.isFinite(num)&&num>0){
+                return`cam${num}`;
+            }
+        }
     }
-    const match=/^cam(\d+)$/i.exec(raw);
-    if(!match){
-        return defaultId;
+    const datasetId=root?.dataset.sessionId||'';
+    if(datasetId){
+        return datasetId;
     }
-    const num=parseInt(match[1],10);
-    return Number.isFinite(num)&&num>0?`cam${num}`:defaultId;
+    return defaultId;
 }
 
 function ensureLocationHash(cellId){
@@ -84,6 +107,16 @@ function ensureLocationHash(cellId){
     }
     const baseUrl=`${window.location.pathname}${window.location.search||''}`;
     window.history.replaceState(null,'',`${baseUrl}${expected}`);
+}
+
+function ensureLocationPath(cellId){
+    const target=`${sessionBase}${cellId}`;
+    const query=window.location.search||'';
+    const hash=window.location.hash||'';
+    if(window.location.pathname===target){
+        return;
+    }
+    window.history.replaceState(null,'',`${target}${query}${hash}`);
 }
 
 function remapDomIds(baseId,targetId){
@@ -119,17 +152,18 @@ function updateRowLabel(cellId){
         return;
     }
     const match=/^cam(\d+)$/i.exec(cellId);
-    if(match){
-        row.dataset.rowLabel=`สตรีม ${match[1]}`;
-    }
+    row.dataset.rowLabel=match?`สตรีม ${match[1]}`:'สตรีม 1';
 }
 
-const requestedCellId=resolveCellId(DEFAULT_CELL_ID);
-const cellId=remapDomIds(DEFAULT_CELL_ID,requestedCellId)||DEFAULT_CELL_ID;
+let cellId=resolveCellId(placeholderId||DEFAULT_CELL_ID);
+cellId=remapDomIds(placeholderId,cellId)||cellId;
 updateRowLabel(cellId);
 ensureLocationHash(cellId);
-
-const sessionIndicator=document.querySelector('[data-current-session-id]');
+ensureLocationPath(cellId);
+if(root){
+    root.dataset.sessionId=cellId;
+    root.dataset.templateMode='false';
+}
 if(sessionIndicator){
     sessionIndicator.textContent=cellId;
 }
@@ -164,19 +198,21 @@ function computeNextCamId(){
 }
 
 function buildTargetHref(baseHref,cam){
-    const href=typeof baseHref==='string'&&baseHref.length>0?baseHref:window.location.pathname;
-    const hashIndex=href.indexOf('#');
-    const cleanBase=hashIndex>-1?href.slice(0,hashIndex):href;
-    return`${cleanBase}#${cam}`;
+    const base=ensureTrailingSlash(typeof baseHref==='string'&&baseHref.length>0?baseHref:sessionBase);
+    return`${base}${cam}`;
+}
+
+function buildSessionHref(cam){
+    return`${sessionBase}${cam}`;
 }
 
 document.querySelectorAll('[data-action="create-new-session"]').forEach(button=>{
     button.addEventListener('click',event=>{
         event.preventDefault();
-        const baseHref=button.getAttribute('data-base-href')||window.location.pathname;
+        const baseHref=button.getAttribute('data-base-href')||sessionBase;
         const nextCam=computeNextCamId();
         const target=buildTargetHref(baseHref,nextCam);
-        window.location.href=target;
+        window.location.href=`${target}#${nextCam}`;
     });
 });
 
@@ -400,7 +436,7 @@ function createController(cellId){
                 sourceId:sourceSelect.value||'',
                 sourceName:sourceOption?sourceOption.textContent:'',
                 page:pageNameEl?pageNameEl.textContent:'',
-                href:`/inference/page#${cellId}`,
+                href:buildSessionHref(cellId),
                 status:'running'
             });
         }

--- a/templates/partials/inference_page_content.html
+++ b/templates/partials/inference_page_content.html
@@ -1,3 +1,23 @@
+<div class="inference-session-toolbar card shadow-sm mb-4">
+    <div class="inference-session-toolbar__body">
+        <div class="inference-session-toolbar__info">
+            <h1 class="inference-session-toolbar__title">Page Inference</h1>
+            <p class="inference-session-toolbar__subtitle">สร้างหลายหน้าควบคุมได้ด้วยรหัส cam1, cam2, ... เพื่อเก็บคะแนนแยกหน้า</p>
+        </div>
+        <div class="inference-session-toolbar__actions">
+            <span class="badge bg-info-subtle text-info inference-session-toolbar__badge">
+                <i class="bi bi-hash me-1"></i><span>Cam ปัจจุบัน:</span>
+                <strong class="ms-1" data-current-session-id>cam1</strong>
+            </span>
+            <a href="{{ url_for('inference_hub') }}" class="btn btn-outline-secondary">
+                <i class="bi bi-arrow-left-circle me-1"></i>กลับหน้า Inference Hub
+            </a>
+            <button type="button" class="btn btn-info text-white" data-action="create-new-session" data-base-href="{{ url_for('inference_page_alias') }}">
+                <i class="bi bi-plus-circle me-1"></i>สร้างหน้าใหม่
+            </button>
+        </div>
+    </div>
+</div>
 
 <div class="cam-row" data-row-label="สตรีม 1">
     <div class="video-col">
@@ -42,6 +62,7 @@
 <script>
 (function(){
 const DEFAULT_CELL_ID='cam1';
+const sessionRegistry=window.InferenceSessions;
 
 function resolveCellId(defaultId){
     const raw=String(window.location.hash||'').replace(/^#/,'').trim();
@@ -108,6 +129,57 @@ const cellId=remapDomIds(DEFAULT_CELL_ID,requestedCellId)||DEFAULT_CELL_ID;
 updateRowLabel(cellId);
 ensureLocationHash(cellId);
 
+const sessionIndicator=document.querySelector('[data-current-session-id]');
+if(sessionIndicator){
+    sessionIndicator.textContent=cellId;
+}
+
+function fallbackNextCamId(currentId){
+    const match=/^cam(\d+)$/i.exec(currentId||'');
+    if(!match){
+        return'cam2';
+    }
+    const nextIndex=parseInt(match[1],10)+1;
+    return`cam${Number.isFinite(nextIndex)&&nextIndex>0?nextIndex:2}`;
+}
+
+function computeNextCamId(){
+    if(sessionRegistry&&typeof sessionRegistry.getNextCamId==='function'){
+        try{
+            const next=sessionRegistry.getNextCamId();
+            if(typeof next==='string'&&next){
+                return next;
+            }
+            if(next&&typeof next.id==='string'&&next.id){
+                return next.id;
+            }
+            if(next&&typeof next.index==='number'&&next.index>0){
+                return`cam${next.index}`;
+            }
+        }catch(err){
+            console.warn('ไม่สามารถอ่านหมายเลข cam ถัดไปจากรีจิสทรีได้',err);
+        }
+    }
+    return fallbackNextCamId(cellId);
+}
+
+function buildTargetHref(baseHref,cam){
+    const href=typeof baseHref==='string'&&baseHref.length>0?baseHref:window.location.pathname;
+    const hashIndex=href.indexOf('#');
+    const cleanBase=hashIndex>-1?href.slice(0,hashIndex):href;
+    return`${cleanBase}#${cam}`;
+}
+
+document.querySelectorAll('[data-action="create-new-session"]').forEach(button=>{
+    button.addEventListener('click',event=>{
+        event.preventDefault();
+        const baseHref=button.getAttribute('data-base-href')||window.location.pathname;
+        const nextCam=computeNextCamId();
+        const target=buildTargetHref(baseHref,nextCam);
+        window.location.href=target;
+    });
+});
+
 function initRoiLayout(cellId){
     const videoCell=document.getElementById(cellId);
     const videoCol=videoCell?videoCell.closest('.video-col'):null;
@@ -138,7 +210,6 @@ function createController(cellId){
     let roiSocket;
     let running=false;
     const cam=`page_${cellId}`;
-    const sessionRegistry=window.InferenceSessions;
     const camRoot=document.getElementById(cellId);
     const camRow=camRoot?camRoot.closest('.cam-row'):null;
     const sessionTitle=camRow&&camRow.dataset.rowLabel?camRow.dataset.rowLabel:cellId;


### PR DESCRIPTION
## Summary
- add a redesigned inference hub landing page with quick actions for group/page flows and a dynamic session list
- share an inference session registry between group and page views to keep the hub list in sync
- refresh navigation/routes and styling to support the new workflow

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cecef139b8832b87e11713b9cde864