### PR TITLE
Revamp inference dashboard overview

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -216,6 +216,114 @@ main.app-main {
   border: 1px solid rgba(148, 163, 184, 0.15);
 }
 
+.dashboard__heading {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  flex: 1 1 280px;
+}
+
+.dashboard__chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.55rem;
+}
+
+.status-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.45rem;
+  padding: 0.45rem 0.95rem;
+  border-radius: 999px;
+  font-size: 0.85rem;
+  font-weight: 600;
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  background: rgba(15, 23, 42, 0.06);
+  color: rgba(15, 23, 42, 0.75);
+  letter-spacing: 0.01em;
+}
+
+.status-chip__dot {
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  background: #22c55e;
+  box-shadow: 0 0 0 0 rgba(34, 197, 94, 0.55);
+  animation: statusPulse 2.4s infinite;
+}
+
+@keyframes statusPulse {
+  0% {
+    box-shadow: 0 0 0 0 rgba(34, 197, 94, 0.55);
+  }
+
+  70% {
+    box-shadow: 0 0 0 12px rgba(34, 197, 94, 0);
+  }
+
+  100% {
+    box-shadow: 0 0 0 0 rgba(34, 197, 94, 0);
+  }
+}
+
+.status-chip--live {
+  background: rgba(34, 197, 94, 0.12);
+  border-color: rgba(34, 197, 94, 0.2);
+  color: #15803d;
+}
+
+.status-chip--sync {
+  background: rgba(59, 130, 246, 0.12);
+  border-color: rgba(59, 130, 246, 0.22);
+  color: #1d4ed8;
+}
+
+.status-chip--roi {
+  background: rgba(14, 165, 233, 0.12);
+  border-color: rgba(14, 165, 233, 0.25);
+  color: #0369a1;
+}
+
+.dashboard__stats {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+  margin-block: 1rem 0.5rem;
+}
+
+.summary-stat {
+  flex: 1 1 220px;
+  background: rgba(255, 255, 255, 0.9);
+  border-radius: var(--radius-lg);
+  padding: 1.1rem 1.3rem;
+  border: 1px solid rgba(148, 163, 184, 0.18);
+  box-shadow: 0 18px 40px -28px rgba(15, 23, 42, 0.55);
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.summary-stat__label {
+  margin: 0;
+  font-size: 0.85rem;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: rgba(15, 23, 42, 0.55);
+}
+
+.summary-stat__value {
+  margin: 0;
+  font-size: clamp(1.6rem, 2.4vw, 2.15rem);
+  font-weight: 700;
+  color: var(--color-text);
+}
+
+.summary-stat__meta {
+  margin: 0;
+  font-size: 0.9rem;
+  color: rgba(15, 23, 42, 0.55);
+}
+
 .dashboard__title {
   font-size: clamp(1.5rem, 2vw, 2rem);
   margin-bottom: 0.25rem;
@@ -279,6 +387,277 @@ main.app-main {
   font-weight: 700;
   margin: 0;
   color: var(--color-text);
+}
+
+.metric-card__meta {
+  margin: 0.25rem 0 0;
+  font-size: 0.9rem;
+  color: rgba(15, 23, 42, 0.55);
+}
+
+.metric-card__meta span {
+  font-weight: 600;
+  color: var(--color-primary);
+}
+
+.dashboard__insights {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: clamp(1.1rem, 2vw, 1.6rem);
+}
+
+.insight-card {
+  background: rgba(255, 255, 255, 0.94);
+  border-radius: var(--radius-lg);
+  padding: 1.3rem 1.5rem;
+  border: 1px solid rgba(148, 163, 184, 0.18);
+  box-shadow: var(--shadow-card);
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.insight-card__header {
+  display: flex;
+  align-items: center;
+  gap: 0.85rem;
+}
+
+.insight-card__icon {
+  width: 44px;
+  height: 44px;
+  border-radius: 14px;
+  display: grid;
+  place-items: center;
+  font-size: 1.3rem;
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.35);
+}
+
+.insight-card__title {
+  margin: 0;
+  font-size: 1.05rem;
+  font-weight: 600;
+}
+
+.insight-card__subtitle {
+  margin: 0;
+  font-size: 0.9rem;
+  color: rgba(15, 23, 42, 0.55);
+}
+
+.insight-card__body {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.insight-card__value {
+  margin: 0;
+  font-size: 1.9rem;
+  font-weight: 700;
+  color: var(--color-text);
+}
+
+.insight-card__value span {
+  color: var(--color-primary);
+}
+
+.insight-card__meta {
+  margin: 0;
+  font-size: 0.9rem;
+  color: rgba(15, 23, 42, 0.6);
+}
+
+.insight-card__progress {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.insight-card__progress-track {
+  width: 100%;
+  height: 9px;
+  border-radius: 999px;
+  background: rgba(148, 163, 184, 0.2);
+  overflow: hidden;
+}
+
+.insight-card__progress-fill {
+  height: 100%;
+  width: 0%;
+  border-radius: inherit;
+  background: linear-gradient(135deg, rgba(34, 197, 94, 0.85), rgba(16, 185, 129, 0.8));
+  transition: width 0.4s ease;
+}
+
+.insight-card__progress-fill--warm {
+  background: linear-gradient(135deg, rgba(251, 191, 36, 0.85), rgba(245, 158, 11, 0.8));
+}
+
+.insight-card__progress-fill--alert {
+  background: linear-gradient(135deg, rgba(248, 113, 113, 0.9), rgba(239, 68, 68, 0.85));
+}
+
+.insight-card__progress-meta {
+  display: flex;
+  justify-content: space-between;
+  font-size: 0.85rem;
+  color: rgba(15, 23, 42, 0.6);
+}
+
+.insight-card__footer {
+  margin-top: auto;
+  display: flex;
+  justify-content: flex-start;
+  font-size: 0.82rem;
+  color: rgba(15, 23, 42, 0.55);
+  gap: 0.35rem;
+}
+
+.insight-card__footer-meta i {
+  margin-right: 0.35rem;
+}
+
+.insight-card--alert .insight-card__value span {
+  color: #dc2626;
+}
+
+.dashboard__panel--accent {
+  background: linear-gradient(135deg, rgba(255, 255, 255, 0.94), rgba(241, 245, 255, 0.92));
+}
+
+.group-overview {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: 1rem;
+}
+
+.group-overview__empty {
+  grid-column: 1 / -1;
+  text-align: center;
+  padding: 1.75rem 1rem;
+  border-radius: var(--radius-md);
+  border: 1px dashed rgba(148, 163, 184, 0.3);
+  color: rgba(15, 23, 42, 0.55);
+}
+
+.group-card {
+  background: rgba(255, 255, 255, 0.95);
+  border-radius: var(--radius-md);
+  padding: 1rem 1.2rem;
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  box-shadow: 0 14px 35px -28px rgba(15, 23, 42, 0.55);
+}
+
+.group-card__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 0.75rem;
+}
+
+.group-card__title {
+  margin: 0;
+  font-weight: 600;
+  color: var(--color-text);
+}
+
+.group-card__badge {
+  padding: 0.35rem 0.65rem;
+  border-radius: 999px;
+  font-size: 0.8rem;
+  font-weight: 600;
+  background: rgba(37, 99, 235, 0.1);
+  color: var(--color-primary);
+}
+
+.group-card__meta {
+  margin: 0;
+  font-size: 0.88rem;
+  color: rgba(15, 23, 42, 0.6);
+}
+
+.group-card__progress-track {
+  width: 100%;
+  height: 7px;
+  border-radius: 999px;
+  background: rgba(148, 163, 184, 0.2);
+  overflow: hidden;
+}
+
+.group-card__progress-fill {
+  height: 100%;
+  width: 0%;
+  border-radius: inherit;
+  background: linear-gradient(135deg, rgba(37, 99, 235, 0.9), rgba(14, 165, 233, 0.85));
+  transition: width 0.4s ease;
+}
+
+.group-card__progress-meta {
+  display: flex;
+  justify-content: space-between;
+  font-size: 0.82rem;
+  color: rgba(15, 23, 42, 0.55);
+}
+
+.group-card__footer {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.6rem 1rem;
+  font-size: 0.82rem;
+  color: rgba(15, 23, 42, 0.6);
+}
+
+.group-card__footer i {
+  margin-right: 0.35rem;
+}
+
+.alert-summary {
+  display: grid;
+  gap: 0.9rem;
+}
+
+.alert-summary__item {
+  padding: 0.9rem 1rem;
+  border-radius: var(--radius-md);
+  background: rgba(15, 23, 42, 0.04);
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.4);
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.alert-summary__title {
+  margin: 0;
+  font-size: 0.85rem;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: rgba(15, 23, 42, 0.6);
+}
+
+.alert-summary__value {
+  margin: 0;
+  font-weight: 600;
+  color: var(--color-text);
+}
+
+.alert-summary__meta {
+  margin: 0;
+  font-size: 0.82rem;
+  color: rgba(15, 23, 42, 0.55);
+}
+
+.alert-summary__empty {
+  text-align: center;
+  padding: 1.5rem 1rem;
+  border-radius: var(--radius-md);
+  background: rgba(15, 23, 42, 0.04);
+  border: 1px dashed rgba(148, 163, 184, 0.25);
+  color: rgba(15, 23, 42, 0.55);
 }
 
 .dashboard__content {
@@ -454,6 +833,14 @@ main.app-main {
 }
 
 @media (max-width: 768px) {
+  .dashboard__stats {
+    margin-block: 1rem;
+  }
+
+  .summary-stat {
+    flex: 1 1 100%;
+  }
+
   .dashboard__metrics {
     grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
   }
@@ -464,6 +851,21 @@ main.app-main {
 
   .stream-grid__item img {
     height: 160px;
+  }
+}
+
+@media (max-width: 576px) {
+  .status-chip {
+    width: 100%;
+    justify-content: center;
+  }
+
+  .dashboard__heading {
+    gap: 0.9rem;
+  }
+
+  .insight-card__value {
+    font-size: 1.6rem;
   }
 }
 

--- a/templates/home.html
+++ b/templates/home.html
@@ -4,14 +4,48 @@
 {% block content %}
 <div class="dashboard">
   <div class="dashboard__header">
-    <div>
-      <h1 class="dashboard__title">แดชบอร์ดภาพรวมงาน</h1>
-      <p class="dashboard__subtitle">ติดตามสถานะกล้อง กลุ่ม Inference และแจ้งเตือนล่าสุดแบบเรียลไทม์</p>
+    <div class="dashboard__heading">
+      <div>
+        <h1 class="dashboard__title">แดชบอร์ดภาพรวมงาน</h1>
+        <p class="dashboard__subtitle">ติดตามสถานะกล้อง กลุ่ม Inference และแจ้งเตือนล่าสุดแบบเรียลไทม์</p>
+      </div>
+      <div class="dashboard__chips">
+        <span class="status-chip status-chip--live">
+          <span class="status-chip__dot"></span>
+          รันอยู่ <span id="chip-running">0</span> กลุ่ม
+        </span>
+        <span class="status-chip status-chip--sync">
+          <i class="bi bi-arrow-repeat"></i>
+          รีเฟรชทุก <span id="chip-refresh">6</span> วินาที
+        </span>
+        <span class="status-chip status-chip--roi">
+          <i class="bi bi-bounding-box-circles"></i>
+          ROI ทั้งหมด <span id="metric-total-roi-chip">0</span>
+        </span>
+      </div>
     </div>
     <div class="dashboard__meta">
       <span class="badge bg-primary-subtle text-primary fw-semibold">
         อัปเดตล่าสุด <span id="dashboard-updated">-</span>
       </span>
+    </div>
+  </div>
+
+  <div class="dashboard__stats">
+    <div class="summary-stat">
+      <p class="summary-stat__label">อัตราออนไลน์</p>
+      <p class="summary-stat__value" id="summary-online-rate">0%</p>
+      <p class="summary-stat__meta">จากกล้องทั้งหมด</p>
+    </div>
+    <div class="summary-stat">
+      <p class="summary-stat__label">กล้องออฟไลน์</p>
+      <p class="summary-stat__value" id="summary-offline">0</p>
+      <p class="summary-stat__meta">ต้องติดตาม</p>
+    </div>
+    <div class="summary-stat">
+      <p class="summary-stat__label">ความหนาแน่นแจ้งเตือน</p>
+      <p class="summary-stat__value" id="summary-alert-density">0.00</p>
+      <p class="summary-stat__meta">ต่อกล้อง/ชั่วโมง</p>
     </div>
   </div>
 
@@ -21,6 +55,7 @@
       <div class="metric-card__body">
         <p class="metric-card__label">จำนวนกล้องทั้งหมด</p>
         <p class="metric-card__value" id="metric-total">0</p>
+        <p class="metric-card__meta">ROI เฝ้าระวัง <span id="metric-total-roi">0</span> โซน</p>
       </div>
     </div>
     <div class="metric-card" data-metric="online">
@@ -28,6 +63,7 @@
       <div class="metric-card__body">
         <p class="metric-card__label">กล้องออนไลน์</p>
         <p class="metric-card__value" id="metric-online">0</p>
+        <p class="metric-card__meta">คิดเป็น <span id="metric-online-rate-meta">0%</span></p>
       </div>
     </div>
     <div class="metric-card" data-metric="running">
@@ -35,6 +71,7 @@
       <div class="metric-card__body">
         <p class="metric-card__label">Inference ที่กำลังรัน</p>
         <p class="metric-card__value" id="metric-running">0</p>
+        <p class="metric-card__meta">โหลดระบบ <span id="metric-running-ratio">0%</span></p>
       </div>
     </div>
     <div class="metric-card" data-metric="alerts">
@@ -42,6 +79,7 @@
       <div class="metric-card__body">
         <p class="metric-card__label">แจ้งเตือนชั่วโมงล่าสุด</p>
         <p class="metric-card__value" id="metric-alerts">0</p>
+        <p class="metric-card__meta">เฉลี่ย <span id="metric-alert-density">0.00</span> / กล้อง</p>
       </div>
     </div>
     <div class="metric-card" data-metric="interval">
@@ -49,6 +87,7 @@
       <div class="metric-card__body">
         <p class="metric-card__label">Interval เฉลี่ย (วินาที)</p>
         <p class="metric-card__value" id="metric-interval">0.0</p>
+        <p class="metric-card__meta">เร็วที่สุด <span id="metric-min-interval">-</span></p>
       </div>
     </div>
     <div class="metric-card" data-metric="fps">
@@ -56,7 +95,92 @@
       <div class="metric-card__body">
         <p class="metric-card__label">FPS เฉลี่ย</p>
         <p class="metric-card__value" id="metric-fps">0.0</p>
+        <p class="metric-card__meta">สูงสุด <span id="metric-max-fps">-</span></p>
       </div>
+    </div>
+  </section>
+
+  <section class="dashboard__insights">
+    <article class="insight-card">
+      <div class="insight-card__header">
+        <span class="insight-card__icon bg-success-subtle text-success"><i class="bi bi-activity"></i></span>
+        <div>
+          <h3 class="insight-card__title">ความพร้อมของกล้อง</h3>
+          <p class="insight-card__subtitle">การออนไลน์ของอุปกรณ์ทั้งหมด</p>
+        </div>
+      </div>
+      <div class="insight-card__body">
+        <p class="insight-card__value" id="insight-online-value">0 / 0</p>
+        <p class="insight-card__meta">ออฟไลน์ <span id="insight-offline">0</span> กล้อง</p>
+        <div class="insight-card__progress">
+          <div class="insight-card__progress-track">
+            <div class="insight-card__progress-fill" id="progress-online"></div>
+          </div>
+          <div class="insight-card__progress-meta">
+            <span>ออนไลน์</span>
+            <span id="insight-online-rate">0%</span>
+          </div>
+        </div>
+      </div>
+    </article>
+    <article class="insight-card">
+      <div class="insight-card__header">
+        <span class="insight-card__icon bg-warning-subtle text-warning"><i class="bi bi-gpu-card"></i></span>
+        <div>
+          <h3 class="insight-card__title">โหลดการประมวลผล</h3>
+          <p class="insight-card__subtitle">จำนวนงาน Inference ที่กำลังทำงาน</p>
+        </div>
+      </div>
+      <div class="insight-card__body">
+        <p class="insight-card__value"><span id="insight-running">0</span> งาน</p>
+        <p class="insight-card__meta">คิดเป็น <span id="insight-running-rate">0%</span> ของกล้องทั้งหมด</p>
+        <div class="insight-card__progress">
+          <div class="insight-card__progress-track">
+            <div class="insight-card__progress-fill insight-card__progress-fill--warm" id="progress-utilization"></div>
+          </div>
+          <div class="insight-card__progress-meta">
+            <span>Average FPS</span>
+            <span id="insight-average-fps">0.0</span>
+          </div>
+        </div>
+      </div>
+    </article>
+    <article class="insight-card insight-card--alert">
+      <div class="insight-card__header">
+        <span class="insight-card__icon bg-danger-subtle text-danger"><i class="bi bi-bell"></i></span>
+        <div>
+          <h3 class="insight-card__title">การแจ้งเตือนล่าสุด</h3>
+          <p class="insight-card__subtitle">ความถี่ของเหตุการณ์ในชั่วโมงที่ผ่านมา</p>
+        </div>
+      </div>
+      <div class="insight-card__body">
+        <p class="insight-card__value"><span id="insight-alerts">0</span> ครั้ง/ชม.</p>
+        <p class="insight-card__meta">เกิดจาก <span id="insight-alert-active">0</span> กล้อง</p>
+        <div class="insight-card__progress">
+          <div class="insight-card__progress-track">
+            <div class="insight-card__progress-fill insight-card__progress-fill--alert" id="progress-alerts"></div>
+          </div>
+          <div class="insight-card__progress-meta">
+            <span>Top Camera</span>
+            <span id="insight-top-camera">-</span>
+          </div>
+        </div>
+      </div>
+      <div class="insight-card__footer">
+        <span class="insight-card__footer-meta"><i class="bi bi-clock-history"></i> อัปเดต <span id="insight-alert-latest">-</span></span>
+      </div>
+    </article>
+  </section>
+
+  <section class="dashboard__panel dashboard__panel--wide dashboard__panel--accent">
+    <div class="panel-header">
+      <div>
+        <h2 class="panel-title">สรุปกลุ่ม Inference</h2>
+        <p class="panel-subtitle">ดูความหนาแน่นของงานในแต่ละกลุ่มและค่า FPS โดยเฉลี่ย</p>
+      </div>
+    </div>
+    <div class="group-overview" id="group-overview">
+      <div class="group-overview__empty">ยังไม่มีกลุ่มที่สร้างไว้</div>
     </div>
   </section>
 
@@ -93,6 +217,17 @@
     </section>
 
     <aside class="dashboard__sidebar">
+      <section class="dashboard__panel">
+        <div class="panel-header">
+          <div>
+            <h2 class="panel-title">สรุปแจ้งเตือน</h2>
+            <p class="panel-subtitle">ดูภาพรวมเหตุการณ์ที่เกิดขึ้นบ่อยและเวลาอัปเดตล่าสุด</p>
+          </div>
+        </div>
+        <div class="alert-summary" id="alert-summary">
+          <div class="alert-summary__empty">ยังไม่มีแจ้งเตือน</div>
+        </div>
+      </section>
       <section class="dashboard__panel">
         <div class="panel-header">
           <div>


### PR DESCRIPTION
## Summary
- redesign the dashboard landing page with real-time status chips, summary stats, insight cards, and dedicated alert overview panels
- refresh the styling for the new dashboard components, including progress visuals, group overview cards, and responsive behaviour
- extend the dashboard script to derive analytics for ROI totals, alert density, group workloads, and drive the new UI sections

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68cf640e93d8832bb86f1d4bb88d8f39