### PR TITLE
feat: redesign inference page card

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -1100,6 +1100,57 @@ button.delete {
   align-self: flex-start;
 }
 
+.page-summary-card {
+  display: flex;
+  flex-direction: column;
+  gap: 0.85rem;
+}
+
+.page-score-chip {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 0.15rem;
+}
+
+.page-score-current {
+  font-size: 1.1rem;
+  font-weight: 600;
+  color: var(--color-primary-strong);
+}
+
+.page-score-body {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.page-score-empty {
+  padding: 0.65rem 0.85rem;
+  border-radius: var(--radius-md);
+  background: rgba(148, 163, 184, 0.16);
+  color: var(--color-muted);
+  text-align: center;
+  font-weight: 500;
+}
+
+.page-score-table {
+  padding: 0.75rem;
+  border-radius: var(--radius-md);
+  background: rgba(248, 250, 252, 0.95);
+  box-shadow: none;
+}
+
+.page-score-table table {
+  width: 100%;
+  margin-bottom: 0;
+}
+
+.page-score-table th,
+.page-score-table td {
+  vertical-align: middle;
+}
+
 .video-card {
   flex: 1 1 auto;
 }
@@ -1124,6 +1175,10 @@ button.delete {
   .roi-list-card {
     flex: 1 1 auto;
     width: 100%;
+  }
+
+  .page-score-chip {
+    align-items: flex-start;
   }
 }
 

--- a/templates/partials/inference_page_content.html
+++ b/templates/partials/inference_page_content.html
@@ -82,6 +82,8 @@
       const intervalInput = getEl('intervalInput');
       const pageNameEl = getEl('pageName');
       const scoreTableBody = getEl('pageScoresBody');
+      const scoreTableWrapper = getEl('pageScoresWrapper');
+      const scoreEmptyEl = getEl('pageScoresEmpty');
       let logTimer;
       let isLogUpdating = false;
       let logSessionId = 0;
@@ -140,13 +142,37 @@
         return `${(seconds * 1000).toFixed(2)} ms`;
       };
 
+      const renderScoreboard = (scores = []) => {
+        if (!scoreTableBody) {
+          return;
+        }
+        scoreTableBody.innerHTML = '';
+        const list = Array.isArray(scores) ? scores : [];
+        list.forEach(item => {
+          const tr = document.createElement('tr');
+          const tdPage = document.createElement('td');
+          tdPage.textContent = item?.page ?? '';
+          const tdScore = document.createElement('td');
+          const scoreValue = typeof item?.score === 'number' ? item.score : null;
+          tdScore.textContent = scoreValue !== null ? scoreValue.toFixed(2) : '';
+          tr.appendChild(tdPage);
+          tr.appendChild(tdScore);
+          scoreTableBody.appendChild(tr);
+        });
+        const hasScores = list.length > 0;
+        if (scoreTableWrapper) {
+          scoreTableWrapper.classList.toggle('d-none', !hasScores);
+        }
+        if (scoreEmptyEl) {
+          scoreEmptyEl.classList.toggle('d-none', hasScores);
+        }
+      };
+
       const resetScoreboard = () => {
         if (pageNameEl) {
-          pageNameEl.textContent = '';
+          pageNameEl.textContent = '-';
         }
-        if (scoreTableBody) {
-          scoreTableBody.innerHTML = '';
-        }
+        renderScoreboard([]);
       };
       resetScoreboard();
 
@@ -653,23 +679,9 @@
             if ('group' in data || Array.isArray(data.scores)) {
               setTimeout(() => {
                 if (pageNameEl) {
-                  pageNameEl.textContent = data.group || '';
+                  pageNameEl.textContent = data.group || '-';
                 }
-                if (scoreTableBody) {
-                  scoreTableBody.innerHTML = '';
-                  const scores = Array.isArray(data.scores) ? data.scores : [];
-                  scores.forEach(item => {
-                    const tr = document.createElement('tr');
-                    const tdPage = document.createElement('td');
-                    tdPage.textContent = item?.page ?? '';
-                    const tdScore = document.createElement('td');
-                    const scoreValue = typeof item?.score === 'number' ? item.score : null;
-                    tdScore.textContent = scoreValue !== null ? scoreValue.toFixed(2) : '';
-                    tr.appendChild(tdPage);
-                    tr.appendChild(tdScore);
-                    scoreTableBody.appendChild(tr);
-                  });
-                }
+                renderScoreboard(data.scores);
               }, 0);
             }
             if (Array.isArray(data.results)) {
@@ -853,14 +865,26 @@
               <div class="video-wrapper">
                 <canvas id="${cellId}-video" class="stream-video"></canvas>
               </div>
-              <div class="mt-3">
-                <p class="mb-1">Page: <span id="${cellId}-pageName"></span></p>
-                <div class="table-responsive mb-0">
-                  <table id="${cellId}-pageScores" class="table table-striped table-sm mb-0">
-                    <thead><tr><th>Page</th><th>Score</th></tr></thead>
-                    <tbody id="${cellId}-pageScoresBody"></tbody>
-                  </table>
-                </div>
+            </div>
+          </div>
+          <div class="card page-summary-card">
+            <div class="d-flex align-items-start justify-content-between flex-wrap gap-3 mb-2">
+              <div>
+                <h6 class="mb-1">ผลการจับหน้าล่าสุด</h6>
+                <p class="mb-0 text-muted small">เรียงตามคะแนนสูงสุดจากงานนี้</p>
+              </div>
+              <div class="page-score-chip text-end">
+                <div class="text-muted small">หน้าปัจจุบัน</div>
+                <div class="page-score-current" id="${cellId}-pageName">-</div>
+              </div>
+            </div>
+            <div class="page-score-body">
+              <div id="${cellId}-pageScoresEmpty" class="page-score-empty">ยังไม่มีผลคะแนน</div>
+              <div id="${cellId}-pageScoresWrapper" class="table-responsive page-score-table d-none">
+                <table id="${cellId}-pageScores" class="table table-striped table-sm mb-0">
+                  <thead><tr><th>Page</th><th>Score</th></tr></thead>
+                  <tbody id="${cellId}-pageScoresBody"></tbody>
+                </table>
               </div>
             </div>
           </div>


### PR DESCRIPTION
## Summary
- rebuild the inference page row markup to introduce a dedicated page summary card with scoreboard placeholders
- enhance the page inference script to render scoreboard data, show empty states, and keep the current page label in sync
- add styling for the new scoreboard card and responsive tweaks to the layout

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cf6832cb2c832b9be336eacd86058c