### PR TITLE
ปรับ UI แดชบอร์ดรองรับงาน Inference แบบกลุ่ม/หน้า และ OCR

### DIFF
--- a/static/js/dashboard.js
+++ b/static/js/dashboard.js
@@ -48,6 +48,34 @@ function setProgress(id, value) {
   el.style.width = `${percent}%`;
 }
 
+function formatResolution(value) {
+  if (!value) {
+    return '-';
+  }
+  let width;
+  let height;
+  if (typeof value === 'string') {
+    return value;
+  }
+  if (Array.isArray(value)) {
+    [width, height] = value;
+  } else if (typeof value === 'object') {
+    ({ width, height } = value);
+  }
+  const w = Number(width);
+  const h = Number(height);
+  if (Number.isFinite(w) && Number.isFinite(h) && w > 0 && h > 0) {
+    return `${w}×${h}`;
+  }
+  if (Number.isFinite(w) && w > 0) {
+    return `${w}`;
+  }
+  if (Number.isFinite(h) && h > 0) {
+    return `${h}`;
+  }
+  return '-';
+}
+
 function updateSummary(summary = {}) {
   setMetric('metric-total', summary.total_cameras ?? 0);
   setMetric('metric-online', summary.online_cameras ?? 0);
@@ -55,11 +83,17 @@ function updateSummary(summary = {}) {
   setMetric('metric-alerts', summary.alerts_last_hour ?? 0);
   setMetric('metric-interval', summary.average_interval ?? 0, 2);
   setMetric('metric-fps', summary.average_fps ?? 0, 2);
+  setMetric('metric-groups', summary.total_groups ?? 0);
+  setMetric('metric-pages', summary.page_jobs ?? 0);
+  setMetric('metric-ocr', summary.ocr_cameras ?? 0);
 
   const total = summary.total_cameras ?? 0;
   const online = summary.online_cameras ?? 0;
   const running = summary.inference_running ?? 0;
   const alerts = summary.alerts_last_hour ?? 0;
+  const runningGroups = summary.running_groups ?? 0;
+  const pageJobsRunning = summary.page_jobs_running ?? 0;
+  const ocrRunning = summary.ocr_running ?? 0;
 
   const offline = Math.max(total - online, 0);
   const onlineRate = total ? (online / total) * 100 : 0;
@@ -72,7 +106,12 @@ function updateSummary(summary = {}) {
   setElementText('metric-online-rate-meta', `${onlineRate.toFixed(0)}%`);
   setElementText('metric-running-ratio', `${runningRate.toFixed(0)}%`);
   setElementText('metric-alert-density', alertDensity.toFixed(2));
-  setElementText('chip-running', running);
+  setElementText('metric-groups-running', runningGroups);
+  setElementText('metric-pages-running', pageJobsRunning);
+  setElementText('metric-ocr-running', ocrRunning);
+  setElementText('chip-group-running', runningGroups);
+  setElementText('chip-page-running', pageJobsRunning);
+  setElementText('chip-ocr-ready', summary.ocr_cameras ?? 0);
 }
 
 function calculateCameraInsights(cameras = []) {
@@ -295,21 +334,8 @@ function updateAlertSummary(alerts = [], analytics = null) {
   });
 }
 
-function updateGroupOverview(cameras = []) {
-  const container = document.getElementById('group-overview');
-  if (!container) return;
-  container.innerHTML = '';
-
-  if (!cameras.length) {
-    const empty = document.createElement('div');
-    empty.className = 'group-overview__empty';
-    empty.textContent = 'ยังไม่มีกลุ่มที่สร้างไว้';
-    container.appendChild(empty);
-    return;
-  }
-
+function aggregateGroupsFromCameras(cameras = []) {
   const groups = new Map();
-
   cameras.forEach((camera) => {
     const key = camera?.group || 'ไม่ระบุกลุ่ม';
     const entry = groups.get(key) || {
@@ -320,6 +346,7 @@ function updateGroupOverview(cameras = []) {
       roi: 0,
       fpsTotal: 0,
       fpsCount: 0,
+      alerts: 0,
     };
 
     entry.cameras += 1;
@@ -343,10 +370,64 @@ function updateGroupOverview(cameras = []) {
       entry.fpsCount += 1;
     }
 
+    const alertsCount = Number(camera?.alerts_count);
+    if (Number.isFinite(alertsCount)) {
+      entry.alerts += alertsCount;
+    }
+
     groups.set(key, entry);
   });
 
-  const sorted = [...groups.values()].sort((a, b) => {
+  return [...groups.values()].map((group) => {
+    const averageFps = group.fpsCount ? group.fpsTotal / group.fpsCount : 0;
+    return {
+      name: group.name,
+      cameras: group.cameras,
+      running: group.running,
+      online: group.online,
+      roi: group.roi,
+      average_fps: averageFps,
+      alerts: group.alerts,
+    };
+  });
+}
+
+function normalizeGroupEntry(group) {
+  const cameras = Number(group?.cameras ?? group?.total ?? 0);
+  const running = Number(group?.running ?? 0);
+  const online = Number(group?.online ?? 0);
+  const roi = Number(group?.roi ?? group?.roi_total ?? 0);
+  const averageFps = Number(group?.average_fps ?? group?.avg_fps ?? 0);
+  const alerts = Number(group?.alerts ?? 0);
+  return {
+    name: group?.name || group?.group || 'ไม่ระบุกลุ่ม',
+    cameras: Number.isFinite(cameras) ? cameras : 0,
+    running: Number.isFinite(running) ? running : 0,
+    online: Number.isFinite(online) ? online : 0,
+    roi: Number.isFinite(roi) ? roi : 0,
+    averageFps: Number.isFinite(averageFps) ? averageFps : 0,
+    alerts: Number.isFinite(alerts) ? alerts : 0,
+  };
+}
+
+function updateGroupOverview(groups = [], cameras = []) {
+  const container = document.getElementById('group-overview');
+  if (!container) return;
+  container.innerHTML = '';
+
+  const dataset = Array.isArray(groups) && groups.length
+    ? groups.map(normalizeGroupEntry)
+    : aggregateGroupsFromCameras(cameras);
+
+  if (!dataset.length) {
+    const empty = document.createElement('div');
+    empty.className = 'group-overview__empty';
+    empty.textContent = 'ยังไม่มีกลุ่มที่สร้างไว้';
+    container.appendChild(empty);
+    return;
+  }
+
+  const sorted = dataset.sort((a, b) => {
     if (b.running !== a.running) {
       return b.running - a.running;
     }
@@ -355,7 +436,6 @@ function updateGroupOverview(cameras = []) {
 
   sorted.forEach((group) => {
     const runningRate = group.cameras ? (group.running / group.cameras) * 100 : 0;
-    const averageFps = group.fpsCount ? group.fpsTotal / group.fpsCount : 0;
 
     const card = document.createElement('article');
     card.className = 'group-card';
@@ -375,7 +455,8 @@ function updateGroupOverview(cameras = []) {
 
     const meta = document.createElement('p');
     meta.className = 'group-card__meta';
-    meta.textContent = `FPS เฉลี่ย ${averageFps.toFixed(1)} · ROI ${group.roi}`;
+    const roiText = Number.isFinite(group.roi) ? group.roi : 0;
+    meta.textContent = `FPS เฉลี่ย ${group.averageFps.toFixed(1)} · ROI ${roiText} · แจ้งเตือน ${group.alerts}`;
 
     const progressTrack = document.createElement('div');
     progressTrack.className = 'group-card__progress-track';
@@ -394,10 +475,199 @@ function updateGroupOverview(cameras = []) {
     footer.innerHTML = `
       <span><i class="bi bi-wifi"></i>ออนไลน์ ${group.online}</span>
       <span><i class="bi bi-camera-video"></i> ${group.cameras} กล้อง</span>
+      <span><i class="bi bi-bell"></i> ${group.alerts}</span>
     `;
 
     card.append(header, meta, progressTrack, progressMeta, footer);
     container.appendChild(card);
+  });
+}
+
+function renderPageCard(job) {
+  const card = document.createElement('article');
+  card.className = 'page-card';
+
+  const header = document.createElement('div');
+  header.className = 'page-card__header';
+
+  const titleWrap = document.createElement('div');
+  titleWrap.className = 'page-card__titles';
+
+  const title = document.createElement('p');
+  title.className = 'page-card__title';
+  title.textContent = job.title || job.cam_id || 'งาน Page';
+
+  const subtitle = document.createElement('p');
+  subtitle.className = 'page-card__subtitle';
+  const groupText = job.group ? `กลุ่ม ${job.group}` : 'ไม่มีกลุ่ม';
+  subtitle.textContent = `${groupText} · ${job.cam_id || '-'}`;
+
+  titleWrap.append(title, subtitle);
+
+  const badge = document.createElement('span');
+  const isRunning = Boolean(job.inference_running);
+  badge.className = `page-card__badge ${isRunning ? 'page-card__badge--running' : 'page-card__badge--idle'}`;
+  badge.textContent = isRunning ? 'กำลังรัน' : (job.status || 'พร้อม');
+
+  header.append(titleWrap, badge);
+
+  const metrics = document.createElement('div');
+  metrics.className = 'page-card__metrics';
+
+  const interval = Number(job.interval);
+  const fps = Number(job.fps);
+  const alerts = Number(job.alerts_count ?? 0);
+
+  const metricData = [
+    { label: 'Interval', value: Number.isFinite(interval) ? `${interval.toFixed(2)}s` : '-' },
+    { label: 'FPS', value: Number.isFinite(fps) ? fps.toFixed(2) : '-' },
+    { label: 'แจ้งเตือน', value: alerts },
+  ];
+
+  metricData.forEach((item) => {
+    const metric = document.createElement('div');
+    metric.className = 'page-card__metric';
+    const label = document.createElement('span');
+    label.className = 'page-card__metric-label';
+    label.textContent = item.label;
+    const value = document.createElement('span');
+    value.className = 'page-card__metric-value';
+    value.textContent = item.value ?? '-';
+    metric.append(label, value);
+    metrics.appendChild(metric);
+  });
+
+  const output = document.createElement('div');
+  output.className = 'page-card__output';
+  const outputLabel = document.createElement('span');
+  outputLabel.className = 'page-card__output-label';
+  outputLabel.textContent = 'ผลล่าสุด';
+  const outputValue = document.createElement('span');
+  outputValue.className = 'page-card__output-value';
+  outputValue.textContent = job.last_output || '-';
+  outputValue.title = job.last_output || '';
+  output.append(outputLabel, outputValue);
+
+  const footer = document.createElement('div');
+  footer.className = 'page-card__footer';
+  footer.innerHTML = `
+    <span><i class="bi bi-clock-history"></i> ${formatDateTime(job.last_activity)}</span>
+    <span><i class="bi bi-bell"></i> ${alerts} ครั้ง</span>
+  `;
+
+  card.append(header, metrics, output, footer);
+  return card;
+}
+
+function updatePageOverview(pageJobs = []) {
+  const container = document.getElementById('page-overview');
+  if (!container) return;
+  container.innerHTML = '';
+
+  if (!Array.isArray(pageJobs) || !pageJobs.length) {
+    const empty = document.createElement('div');
+    empty.className = 'page-overview__empty';
+    empty.textContent = 'ยังไม่มีงาน Page Inference';
+    container.appendChild(empty);
+    return;
+  }
+
+  pageJobs.forEach((job) => {
+    container.appendChild(renderPageCard(job));
+  });
+}
+
+function renderOcrCard(camera) {
+  const card = document.createElement('article');
+  card.className = 'ocr-card';
+
+  const header = document.createElement('div');
+  header.className = 'ocr-card__header';
+
+  const titleWrap = document.createElement('div');
+  titleWrap.className = 'ocr-card__titles';
+
+  const title = document.createElement('p');
+  title.className = 'ocr-card__title';
+  title.textContent = camera.name || camera.cam_id || 'กล้อง';
+
+  const subtitle = document.createElement('p');
+  subtitle.className = 'ocr-card__subtitle';
+  const groupText = camera.group ? `กลุ่ม ${camera.group}` : 'ไม่มีกลุ่ม';
+  subtitle.textContent = `${camera.cam_id || '-'} · ${groupText}`;
+
+  titleWrap.append(title, subtitle);
+
+  const badge = document.createElement('span');
+  const running = Boolean(camera.inference_running);
+  badge.className = `ocr-card__badge ${running ? 'ocr-card__badge--running' : 'ocr-card__badge--idle'}`;
+  badge.textContent = running ? 'กำลังรัน' : (camera.status || 'พร้อม');
+
+  header.append(titleWrap, badge);
+
+  const metrics = document.createElement('div');
+  metrics.className = 'ocr-card__metrics';
+
+  const interval = Number(camera.interval);
+  const fps = Number(camera.fps);
+
+  const metricItems = [
+    { label: 'ROI', value: camera.roi_count ?? 0 },
+    { label: 'Interval', value: Number.isFinite(interval) ? `${interval.toFixed(2)}s` : '-' },
+    { label: 'FPS', value: Number.isFinite(fps) ? fps.toFixed(2) : '-' },
+    { label: 'ความละเอียด', value: formatResolution(camera.resolution) },
+  ];
+
+  metricItems.forEach((item) => {
+    const metric = document.createElement('div');
+    metric.className = 'ocr-card__metric';
+    const label = document.createElement('span');
+    label.className = 'ocr-card__metric-label';
+    label.textContent = item.label;
+    const value = document.createElement('span');
+    value.className = 'ocr-card__metric-value';
+    value.textContent = item.value ?? '-';
+    metric.append(label, value);
+    metrics.appendChild(metric);
+  });
+
+  const output = document.createElement('div');
+  output.className = 'ocr-card__output';
+  const outputLabel = document.createElement('span');
+  outputLabel.className = 'ocr-card__output-label';
+  outputLabel.textContent = 'ผลล่าสุด';
+  const outputValue = document.createElement('span');
+  outputValue.className = 'ocr-card__output-value';
+  outputValue.textContent = camera.last_output || '-';
+  outputValue.title = camera.last_output || '';
+  output.append(outputLabel, outputValue);
+
+  const footer = document.createElement('div');
+  footer.className = 'ocr-card__footer';
+  footer.innerHTML = `
+    <span><i class="bi bi-clock-history"></i> ${formatDateTime(camera.last_activity)}</span>
+    <span><i class="bi bi-info-circle"></i> ${camera.status || '-'}</span>
+  `;
+
+  card.append(header, metrics, output, footer);
+  return card;
+}
+
+function updateOcrOverview(cameras = []) {
+  const container = document.getElementById('ocr-overview');
+  if (!container) return;
+  container.innerHTML = '';
+
+  if (!Array.isArray(cameras) || !cameras.length) {
+    const empty = document.createElement('div');
+    empty.className = 'ocr-overview__empty';
+    empty.textContent = 'ยังไม่มีกล้องที่ตั้งค่างาน OCR';
+    container.appendChild(empty);
+    return;
+  }
+
+  cameras.forEach((camera) => {
+    container.appendChild(renderOcrCard(camera));
   });
 }
 
@@ -408,6 +678,12 @@ function createCameraRow(camera) {
   const camId = document.createElement('div');
   camId.className = 'fw-semibold';
   camId.textContent = camera.cam_id ?? '-';
+  if (camera.is_ocr) {
+    const ocrBadge = document.createElement('span');
+    ocrBadge.className = 'badge bg-primary-subtle text-primary ms-2';
+    ocrBadge.textContent = 'OCR';
+    camId.appendChild(ocrBadge);
+  }
   const camMeta = document.createElement('div');
   camMeta.className = 'text-muted small';
   const backend = camera.backend || '-';
@@ -423,6 +699,9 @@ function createCameraRow(camera) {
   camSource.className = 'text-muted small';
   camSource.textContent = camera.source || '-';
   secondCell.append(camName, camSource);
+
+  const resolutionCell = document.createElement('td');
+  resolutionCell.textContent = formatResolution(camera.resolution);
 
   const statusCell = document.createElement('td');
   const statusBadge = document.createElement('span');
@@ -463,6 +742,7 @@ function createCameraRow(camera) {
   tr.append(
     firstCell,
     secondCell,
+    resolutionCell,
     statusCell,
     groupCell,
     intervalCell,
@@ -481,7 +761,7 @@ function updateCameraTable(cameras = []) {
   tbody.innerHTML = '';
   if (!cameras.length) {
     const emptyRow = document.createElement('tr');
-    emptyRow.innerHTML = '<td colspan="9" class="text-center text-muted py-4">ไม่มีข้อมูลกล้อง</td>';
+    emptyRow.innerHTML = '<td colspan="10" class="text-center text-muted py-4">ไม่มีข้อมูลกล้อง</td>';
     tbody.appendChild(emptyRow);
     return;
   }
@@ -614,7 +894,9 @@ async function loadDashboard() {
     updateCameraTable(data.cameras);
     updateAlerts(data.alerts);
     updateAlertSummary(data.alerts, alertAnalytics);
-    updateGroupOverview(data.cameras);
+    updateGroupOverview(data.groups, data.cameras);
+    updatePageOverview(data.page_jobs);
+    updateOcrOverview(data.ocr_cameras);
     updateStreams(data.cameras);
     updateGeneratedAt(data.generated_at);
   } catch (error) {

--- a/static/style.css
+++ b/static/style.css
@@ -284,6 +284,18 @@ main.app-main {
   color: #0369a1;
 }
 
+.status-chip--page {
+  background: rgba(129, 140, 248, 0.16);
+  border-color: rgba(129, 140, 248, 0.28);
+  color: #4338ca;
+}
+
+.status-chip--ocr {
+  background: rgba(234, 179, 8, 0.15);
+  border-color: rgba(234, 179, 8, 0.28);
+  color: #b45309;
+}
+
 .dashboard__stats {
   display: flex;
   flex-wrap: wrap;
@@ -612,6 +624,172 @@ main.app-main {
 }
 
 .group-card__footer i {
+  margin-right: 0.35rem;
+}
+
+.page-overview,
+.ocr-overview {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 1rem;
+}
+
+.page-overview__empty,
+.ocr-overview__empty {
+  grid-column: 1 / -1;
+  text-align: center;
+  padding: 1.75rem 1rem;
+  border-radius: var(--radius-md);
+  border: 1px dashed rgba(148, 163, 184, 0.3);
+  color: rgba(15, 23, 42, 0.55);
+}
+
+.page-card,
+.ocr-card {
+  background: rgba(255, 255, 255, 0.95);
+  border-radius: var(--radius-md);
+  border: 1px solid rgba(148, 163, 184, 0.18);
+  padding: 1rem 1.2rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.8rem;
+  box-shadow: 0 18px 42px -30px rgba(15, 23, 42, 0.55);
+}
+
+.page-card__header,
+.ocr-card__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 0.75rem;
+}
+
+.page-card__titles,
+.ocr-card__titles {
+  display: flex;
+  flex-direction: column;
+  gap: 0.2rem;
+}
+
+.page-card__title,
+.ocr-card__title {
+  margin: 0;
+  font-weight: 600;
+  color: var(--color-text);
+}
+
+.page-card__subtitle,
+.ocr-card__subtitle {
+  margin: 0;
+  font-size: 0.82rem;
+  color: rgba(15, 23, 42, 0.55);
+}
+
+.page-card__badge,
+.ocr-card__badge {
+  padding: 0.35rem 0.7rem;
+  border-radius: 999px;
+  font-size: 0.78rem;
+  font-weight: 600;
+  background: rgba(148, 163, 184, 0.2);
+  color: rgba(15, 23, 42, 0.65);
+  white-space: nowrap;
+}
+
+.page-card__badge--running {
+  background: rgba(34, 197, 94, 0.15);
+  color: #15803d;
+}
+
+.page-card__badge--idle {
+  background: rgba(148, 163, 184, 0.18);
+  color: rgba(15, 23, 42, 0.65);
+}
+
+.ocr-card__badge--running {
+  background: rgba(59, 130, 246, 0.18);
+  color: #1d4ed8;
+}
+
+.ocr-card__badge--idle {
+  background: rgba(251, 191, 36, 0.22);
+  color: #b45309;
+}
+
+.page-card__metrics,
+.ocr-card__metrics {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+  gap: 0.6rem;
+}
+
+.page-card__metric,
+.ocr-card__metric {
+  display: flex;
+  flex-direction: column;
+  gap: 0.2rem;
+  padding: 0.65rem 0.75rem;
+  border-radius: var(--radius-md);
+  background: rgba(15, 23, 42, 0.03);
+  border: 1px solid rgba(148, 163, 184, 0.18);
+}
+
+.page-card__metric-label,
+.ocr-card__metric-label {
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: rgba(15, 23, 42, 0.55);
+}
+
+.page-card__metric-value,
+.ocr-card__metric-value {
+  font-size: 0.95rem;
+  font-weight: 600;
+  color: var(--color-text);
+}
+
+.page-card__output,
+.ocr-card__output {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  background: rgba(14, 165, 233, 0.06);
+  border: 1px solid rgba(14, 165, 233, 0.18);
+  border-radius: var(--radius-md);
+  padding: 0.75rem 0.9rem;
+}
+
+.page-card__output-label,
+.ocr-card__output-label {
+  font-size: 0.78rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: rgba(15, 23, 42, 0.55);
+}
+
+.page-card__output-value,
+.ocr-card__output-value {
+  font-size: 0.95rem;
+  font-weight: 600;
+  color: var(--color-text);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.page-card__footer,
+.ocr-card__footer {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.6rem 1rem;
+  font-size: 0.82rem;
+  color: rgba(15, 23, 42, 0.6);
+}
+
+.page-card__footer i,
+.ocr-card__footer i {
   margin-right: 0.35rem;
 }
 

--- a/templates/home.html
+++ b/templates/home.html
@@ -7,12 +7,16 @@
     <div class="dashboard__heading">
       <div>
         <h1 class="dashboard__title">แดชบอร์ดภาพรวมงาน</h1>
-        <p class="dashboard__subtitle">ติดตามสถานะกล้อง กลุ่ม Inference และแจ้งเตือนล่าสุดแบบเรียลไทม์</p>
+        <p class="dashboard__subtitle">ติดตามสถานะกล้อง งาน Inference แบบกลุ่มและแบบหน้า พร้อมข้อมูล OCR ที่จำเป็นในที่เดียว</p>
       </div>
       <div class="dashboard__chips">
         <span class="status-chip status-chip--live">
           <span class="status-chip__dot"></span>
-          รันอยู่ <span id="chip-running">0</span> กลุ่ม
+          กลุ่มรันอยู่ <span id="chip-group-running">0</span>
+        </span>
+        <span class="status-chip status-chip--page">
+          <i class="bi bi-layers"></i>
+          Page รันอยู่ <span id="chip-page-running">0</span>
         </span>
         <span class="status-chip status-chip--sync">
           <i class="bi bi-arrow-repeat"></i>
@@ -21,6 +25,10 @@
         <span class="status-chip status-chip--roi">
           <i class="bi bi-bounding-box-circles"></i>
           ROI ทั้งหมด <span id="metric-total-roi-chip">0</span>
+        </span>
+        <span class="status-chip status-chip--ocr">
+          <i class="bi bi-type"></i>
+          OCR พร้อมใช้งาน <span id="chip-ocr-ready">0</span>
         </span>
       </div>
     </div>
@@ -74,6 +82,14 @@
         <p class="metric-card__meta">โหลดระบบ <span id="metric-running-ratio">0%</span></p>
       </div>
     </div>
+    <div class="metric-card" data-metric="groups">
+      <div class="metric-card__icon bg-secondary text-white"><i class="bi bi-diagram-3"></i></div>
+      <div class="metric-card__body">
+        <p class="metric-card__label">จำนวนกลุ่ม</p>
+        <p class="metric-card__value" id="metric-groups">0</p>
+        <p class="metric-card__meta">รันอยู่ <span id="metric-groups-running">0</span> กลุ่ม</p>
+      </div>
+    </div>
     <div class="metric-card" data-metric="alerts">
       <div class="metric-card__icon bg-danger text-white"><i class="bi bi-bell"></i></div>
       <div class="metric-card__body">
@@ -96,6 +112,22 @@
         <p class="metric-card__label">FPS เฉลี่ย</p>
         <p class="metric-card__value" id="metric-fps">0.0</p>
         <p class="metric-card__meta">สูงสุด <span id="metric-max-fps">-</span></p>
+      </div>
+    </div>
+    <div class="metric-card" data-metric="pages">
+      <div class="metric-card__icon bg-primary-subtle text-primary"><i class="bi bi-journal-text"></i></div>
+      <div class="metric-card__body">
+        <p class="metric-card__label">งาน Page ทั้งหมด</p>
+        <p class="metric-card__value" id="metric-pages">0</p>
+        <p class="metric-card__meta">กำลังรัน <span id="metric-pages-running">0</span> งาน</p>
+      </div>
+    </div>
+    <div class="metric-card" data-metric="ocr">
+      <div class="metric-card__icon bg-light text-primary"><i class="bi bi-type"></i></div>
+      <div class="metric-card__body">
+        <p class="metric-card__label">กล้องสำหรับ OCR</p>
+        <p class="metric-card__value" id="metric-ocr">0</p>
+        <p class="metric-card__meta">รันอยู่ <span id="metric-ocr-running">0</span> กล้อง</p>
       </div>
     </div>
   </section>
@@ -176,11 +208,35 @@
     <div class="panel-header">
       <div>
         <h2 class="panel-title">สรุปกลุ่ม Inference</h2>
-        <p class="panel-subtitle">ดูความหนาแน่นของงานในแต่ละกลุ่มและค่า FPS โดยเฉลี่ย</p>
+        <p class="panel-subtitle">ดูความหนาแน่นของงานในแต่ละกลุ่ม ค่า FPS เฉลี่ย และจำนวนการแจ้งเตือนล่าสุด</p>
       </div>
     </div>
     <div class="group-overview" id="group-overview">
       <div class="group-overview__empty">ยังไม่มีกลุ่มที่สร้างไว้</div>
+    </div>
+  </section>
+
+  <section class="dashboard__panel dashboard__panel--wide">
+    <div class="panel-header">
+      <div>
+        <h2 class="panel-title">ภาพรวม Page Inference</h2>
+        <p class="panel-subtitle">ติดตามงานแบบหน้า (Page) สำหรับเอกสารหรือฟอร์มที่กำลังประมวลผล</p>
+      </div>
+    </div>
+    <div class="page-overview" id="page-overview">
+      <div class="page-overview__empty">ยังไม่มีงาน Page Inference</div>
+    </div>
+  </section>
+
+  <section class="dashboard__panel dashboard__panel--wide">
+    <div class="panel-header">
+      <div>
+        <h2 class="panel-title">ข้อมูลสำคัญสำหรับงาน OCR แบบกล้อง</h2>
+        <p class="panel-subtitle">รวมกล้องที่กำหนด ROI ไว้สำหรับ OCR พร้อมรายละเอียดที่จำเป็น</p>
+      </div>
+    </div>
+    <div class="ocr-overview" id="ocr-overview">
+      <div class="ocr-overview__empty">ยังไม่มีกล้องที่ตั้งค่างาน OCR</div>
     </div>
   </section>
 
@@ -189,7 +245,7 @@
       <div class="panel-header">
         <div>
           <h2 class="panel-title">สถานะกล้องและงานประมวลผล</h2>
-          <p class="panel-subtitle">ดูรายละเอียดกล้องทั้งหมดพร้อมสถานะ กลุ่มที่รันอยู่ และความถี่การประมวลผล</p>
+          <p class="panel-subtitle">ดูรายละเอียดกล้องทั้งหมดพร้อมสถานะ กลุ่มที่รันอยู่ ความละเอียด และข้อมูลล่าสุดเพื่อการทำ OCR</p>
         </div>
       </div>
       <div class="table-responsive dashboard__table-wrapper">
@@ -198,6 +254,7 @@
             <tr>
               <th>กล้อง</th>
               <th>ชื่อ/แหล่งสัญญาณ</th>
+              <th>ความละเอียด</th>
               <th>สถานะ</th>
               <th>กลุ่มที่กำลังใช้</th>
               <th>Interval</th>
@@ -209,7 +266,7 @@
           </thead>
           <tbody id="camera-table-body">
             <tr>
-              <td colspan="9" class="text-center text-muted py-4">ไม่มีข้อมูลกล้อง</td>
+              <td colspan="10" class="text-center text-muted py-4">ไม่มีข้อมูลกล้อง</td>
             </tr>
           </tbody>
         </table>


### PR DESCRIPTION
## สรุป
- ขยาย payload แดชบอร์ดให้รวมข้อมูลกลุ่มงาน, งานแบบหน้า และรายละเอียดกล้องสำหรับ OCR
- ปรับหน้าแดชบอร์ดให้แสดงการ์ดสรุปใหม่, ตารางเพิ่มคอลัมน์ความละเอียด และเพิ่มเซกชัน Page/OCR overview
- ปรับสคริปต์แดชบอร์ดเพื่อแสดงผลข้อมูลใหม่พร้อมสไตล์ที่ดูเป็นมืออาชีพมากขึ้น

## การทดสอบ
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68cf7afdfb10832b83d254e9d3066efd