### PR TITLE
ปรับ UI แดชบอร์ด เพิ่ม ROI และสถิติการประมวลผล

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -355,12 +355,6 @@ main.app-main {
   backdrop-filter: blur(6px);
 }
 
-.dashboard__metrics {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
-  gap: clamp(1rem, 2vw, 1.5rem);
-}
-
 .roi-overview {
   display: flex;
   flex-direction: column;
@@ -644,57 +638,6 @@ main.app-main {
   .dashboard__table-wrapper--compact table {
     font-size: 0.88rem;
   }
-}
-
-.metric-card {
-  display: flex;
-  align-items: center;
-  gap: 1rem;
-  padding: 1.25rem 1.5rem;
-  border-radius: var(--radius-lg);
-  background: rgba(255, 255, 255, 0.92);
-  box-shadow: var(--shadow-card);
-  border: 1px solid rgba(15, 23, 42, 0.08);
-  transition: transform 0.2s ease, box-shadow 0.2s ease;
-}
-
-.metric-card:hover {
-  transform: translateY(-3px);
-  box-shadow: 0 20px 45px -25px rgba(15, 23, 42, 0.55);
-}
-
-.metric-card__icon {
-  width: 56px;
-  height: 56px;
-  border-radius: 18px;
-  display: grid;
-  place-items: center;
-  font-size: 1.5rem;
-  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.2);
-}
-
-.metric-card__label {
-  margin: 0;
-  font-weight: 500;
-  color: rgba(15, 23, 42, 0.65);
-}
-
-.metric-card__value {
-  font-size: clamp(1.6rem, 2.4vw, 2.2rem);
-  font-weight: 700;
-  margin: 0;
-  color: var(--color-text);
-}
-
-.metric-card__meta {
-  margin: 0.25rem 0 0;
-  font-size: 0.9rem;
-  color: rgba(15, 23, 42, 0.55);
-}
-
-.metric-card__meta span {
-  font-weight: 600;
-  color: var(--color-primary);
 }
 
 .dashboard__insights {
@@ -1127,6 +1070,15 @@ main.app-main {
   grid-column: 1 / -1;
 }
 
+.dashboard__panel--scroll {
+  max-height: 420px;
+  overflow: hidden;
+}
+
+.dashboard__panel--scroll .timeline {
+  max-height: 100%;
+}
+
 .panel-header {
   display: flex;
   justify-content: space-between;
@@ -1294,16 +1246,16 @@ main.app-main {
     flex: 1 1 100%;
   }
 
-  .dashboard__metrics {
-    grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
-  }
-
-  .metric-card {
-    padding: 1rem 1.25rem;
-  }
-
   .stream-grid__item img {
     height: 160px;
+  }
+
+  .dashboard__panel--scroll {
+    max-height: none;
+  }
+
+  .dashboard__panel--scroll .timeline {
+    max-height: none;
   }
 }
 

--- a/static/style.css
+++ b/static/style.css
@@ -1098,7 +1098,7 @@ main.app-main {
 
 .dashboard__content {
   display: grid;
-  grid-template-columns: minmax(0, 1fr) 340px;
+  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
   gap: clamp(1.5rem, 2vw, 2rem);
   align-items: start;
 }
@@ -1113,6 +1113,10 @@ main.app-main {
 
 .dashboard__panel--wide {
   grid-column: 1 / 2;
+}
+
+.dashboard__panel--full {
+  grid-column: 1 / -1;
 }
 
 .panel-header {

--- a/static/style.css
+++ b/static/style.css
@@ -1054,6 +1054,11 @@ main.app-main {
 .alert-summary {
   display: grid;
   gap: 0.9rem;
+  flex: 1;
+  overflow-y: auto;
+  min-height: 0;
+  padding-right: 0.35rem;
+  scrollbar-gutter: stable both-edge;
 }
 
 .alert-summary__item {
@@ -1100,7 +1105,7 @@ main.app-main {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
   gap: clamp(1.5rem, 2vw, 2rem);
-  align-items: start;
+  align-items: stretch;
 }
 
 .dashboard__panel {
@@ -1109,6 +1114,9 @@ main.app-main {
   padding: clamp(1.25rem, 1.8vw, 1.75rem);
   box-shadow: var(--shadow-card);
   border: 1px solid rgba(148, 163, 184, 0.18);
+  display: flex;
+  flex-direction: column;
+  height: 100%;
 }
 
 .dashboard__panel--wide {
@@ -1163,6 +1171,11 @@ main.app-main {
   display: flex;
   flex-direction: column;
   gap: 1rem;
+  flex: 1;
+  overflow-y: auto;
+  min-height: 0;
+  padding-right: 0.35rem;
+  scrollbar-gutter: stable both-edge;
 }
 
 .timeline__item {

--- a/static/style.css
+++ b/static/style.css
@@ -290,6 +290,12 @@ main.app-main {
   color: #4338ca;
 }
 
+.status-chip--processing {
+  background: rgba(234, 179, 8, 0.16);
+  border-color: rgba(234, 179, 8, 0.28);
+  color: #b45309;
+}
+
 .dashboard__stats {
   display: flex;
   flex-wrap: wrap;
@@ -353,6 +359,291 @@ main.app-main {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
   gap: clamp(1rem, 2vw, 1.5rem);
+}
+
+.roi-overview {
+  display: flex;
+  flex-direction: column;
+  gap: clamp(1rem, 1.8vw, 1.6rem);
+}
+
+.roi-overview__stats {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+}
+
+.roi-stat {
+  background: rgba(255, 255, 255, 0.92);
+  border-radius: var(--radius-md);
+  padding: 1rem 1.2rem;
+  border: 1px solid rgba(148, 163, 184, 0.18);
+  box-shadow: var(--shadow-card);
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.roi-stat__label {
+  margin: 0;
+  font-size: 0.8rem;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: rgba(15, 23, 42, 0.5);
+}
+
+.roi-stat__value {
+  margin: 0;
+  font-size: clamp(1.4rem, 2.4vw, 1.9rem);
+  font-weight: 700;
+  color: var(--color-text);
+}
+
+.roi-stat__meta {
+  margin: 0;
+  font-size: 0.85rem;
+  color: rgba(15, 23, 42, 0.55);
+}
+
+.roi-overview__body {
+  display: grid;
+  grid-template-columns: minmax(0, 1.4fr) minmax(0, 1fr);
+  gap: clamp(1rem, 2vw, 1.6rem);
+}
+
+.roi-overview__modules,
+.roi-overview__performance {
+  background: rgba(255, 255, 255, 0.9);
+  border-radius: var(--radius-lg);
+  padding: 1.25rem 1.5rem;
+  border: 1px solid rgba(148, 163, 184, 0.16);
+  box-shadow: var(--shadow-card);
+  display: flex;
+  flex-direction: column;
+  gap: 1.1rem;
+}
+
+.roi-overview__title {
+  margin: 0;
+  font-size: 1rem;
+  font-weight: 600;
+  color: rgba(15, 23, 42, 0.75);
+}
+
+.roi-module-list {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 1rem;
+}
+
+.roi-module-card {
+  border-radius: var(--radius-md);
+  border: 1px solid rgba(148, 163, 184, 0.18);
+  background: linear-gradient(135deg, rgba(255, 255, 255, 0.95), rgba(241, 245, 249, 0.85));
+  padding: 1rem 1.25rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  box-shadow: 0 16px 38px -28px rgba(15, 23, 42, 0.6);
+}
+
+.roi-module-card__title {
+  margin: 0;
+  font-weight: 600;
+  color: var(--color-text);
+}
+
+.roi-module-card__meta {
+  margin: 0;
+  font-size: 0.85rem;
+  color: rgba(15, 23, 42, 0.55);
+}
+
+.roi-module-card__value {
+  margin: 0;
+  font-size: 1.35rem;
+  font-weight: 600;
+  color: var(--color-primary);
+}
+
+.roi-module-card__footer {
+  margin: 0;
+  font-size: 0.8rem;
+  color: rgba(15, 23, 42, 0.5);
+}
+
+.roi-module-card__tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.35rem;
+  margin-top: 0.35rem;
+}
+
+.roi-module-card__tag {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.2rem 0.65rem;
+  border-radius: 999px;
+  background: rgba(59, 130, 246, 0.12);
+  color: #1d4ed8;
+  font-size: 0.75rem;
+  font-weight: 600;
+  letter-spacing: 0.03em;
+}
+
+.roi-module-list__empty {
+  grid-column: 1 / -1;
+  padding: 1rem 1.25rem;
+  border-radius: var(--radius-md);
+  background: rgba(148, 163, 184, 0.12);
+  color: rgba(15, 23, 42, 0.6);
+  text-align: center;
+}
+
+.performance-cards {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+}
+
+.performance-card {
+  border-radius: var(--radius-md);
+  padding: 1rem 1.25rem;
+  color: rgba(15, 23, 42, 0.85);
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+  border: 1px solid rgba(148, 163, 184, 0.18);
+}
+
+.performance-card--fast {
+  background: linear-gradient(135deg, rgba(187, 247, 208, 0.85), rgba(134, 239, 172, 0.75));
+  color: #166534;
+}
+
+.performance-card--slow {
+  background: linear-gradient(135deg, rgba(254, 226, 226, 0.88), rgba(252, 165, 165, 0.68));
+  color: #b91c1c;
+}
+
+.performance-card__label {
+  margin: 0;
+  font-size: 0.85rem;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  font-weight: 600;
+}
+
+.performance-card__title {
+  margin: 0;
+  font-size: 1.05rem;
+  font-weight: 700;
+}
+
+.performance-card__value {
+  margin: 0;
+  font-size: 1.4rem;
+  font-weight: 700;
+}
+
+.performance-card__meta {
+  margin: 0;
+  font-size: 0.85rem;
+}
+
+.module-badge-group {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.35rem;
+}
+
+.module-badge {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.25rem 0.65rem;
+  border-radius: 999px;
+  background: rgba(99, 102, 241, 0.14);
+  color: #4338ca;
+  font-size: 0.78rem;
+  font-weight: 600;
+}
+
+.module-badge-meta {
+  margin-top: 0.35rem;
+  font-size: 0.75rem;
+  color: rgba(15, 23, 42, 0.5);
+}
+
+.processing-status {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0.3rem 0.65rem;
+  border-radius: 999px;
+  font-size: 0.82rem;
+  font-weight: 600;
+}
+
+.processing-status--ok {
+  background: rgba(34, 197, 94, 0.16);
+  color: #15803d;
+}
+
+.processing-status--risk {
+  background: rgba(239, 68, 68, 0.16);
+  color: #b91c1c;
+}
+
+.processing-status--idle {
+  background: rgba(148, 163, 184, 0.18);
+  color: #475569;
+}
+
+.processing-status--unknown {
+  background: rgba(59, 130, 246, 0.16);
+  color: #1d4ed8;
+}
+
+.dashboard__table-wrapper--compact table {
+  font-size: 0.92rem;
+}
+
+.dashboard__table-wrapper--compact th {
+  font-size: 0.78rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: rgba(15, 23, 42, 0.55);
+}
+
+.dashboard__table-wrapper--compact td {
+  vertical-align: middle;
+}
+
+.roi-source-name {
+  font-weight: 600;
+  margin-bottom: 0.1rem;
+}
+
+.roi-source-meta {
+  margin: 0;
+  font-size: 0.78rem;
+  color: rgba(15, 23, 42, 0.55);
+}
+
+@media (max-width: 1200px) {
+  .roi-overview__body {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (max-width: 768px) {
+  .roi-overview__stats {
+    grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+  }
+
+  .dashboard__table-wrapper--compact table {
+    font-size: 0.88rem;
+  }
 }
 
 .metric-card {

--- a/templates/home.html
+++ b/templates/home.html
@@ -309,7 +309,7 @@
   </section>
 
   <div class="dashboard__content">
-    <section class="dashboard__panel dashboard__panel--wide">
+    <section class="dashboard__panel dashboard__panel--full">
       <div class="panel-header">
         <div>
           <h2 class="panel-title">สถานะกล้องและงานประมวลผล</h2>
@@ -341,31 +341,28 @@
       </div>
     </section>
 
-    <aside class="dashboard__sidebar">
-      <section class="dashboard__panel">
-        <div class="panel-header">
-          <div>
-            <h2 class="panel-title">สรุปแจ้งเตือน</h2>
-            <p class="panel-subtitle">ดูภาพรวมเหตุการณ์ที่เกิดขึ้นบ่อยและเวลาอัปเดตล่าสุด</p>
-          </div>
+    <section class="dashboard__panel">
+      <div class="panel-header">
+        <div>
+          <h2 class="panel-title">สรุปแจ้งเตือน</h2>
+          <p class="panel-subtitle">ดูภาพรวมเหตุการณ์ที่เกิดขึ้นบ่อยและเวลาอัปเดตล่าสุด</p>
         </div>
-        <div class="alert-summary" id="alert-summary">
-          <div class="alert-summary__empty">ยังไม่มีแจ้งเตือน</div>
+      </div>
+      <div class="alert-summary" id="alert-summary">
+        <div class="alert-summary__empty">ยังไม่มีแจ้งเตือน</div>
+      </div>
+    </section>
+    <section class="dashboard__panel">
+      <div class="panel-header">
+        <div>
+          <h2 class="panel-title">แจ้งเตือนล่าสุด</h2>
+          <p class="panel-subtitle">ผลลัพธ์ที่ระบบบันทึกไว้ล่าสุด (สูงสุด 20 รายการ)</p>
         </div>
-      </section>
-      <section class="dashboard__panel">
-        <div class="panel-header">
-          <div>
-            <h2 class="panel-title">แจ้งเตือนล่าสุด</h2>
-            <p class="panel-subtitle">ผลลัพธ์ที่ระบบบันทึกไว้ล่าสุด (สูงสุด 20 รายการ)</p>
-          </div>
-        </div>
-        <ul class="timeline" id="alert-timeline">
-          <li class="timeline__empty">ยังไม่มีแจ้งเตือน</li>
-        </ul>
-      </section>
-
-    </aside>
+      </div>
+      <ul class="timeline" id="alert-timeline">
+        <li class="timeline__empty">ยังไม่มีแจ้งเตือน</li>
+      </ul>
+    </section>
   </div>
 
   <section class="dashboard__panel">

--- a/templates/home.html
+++ b/templates/home.html
@@ -14,6 +14,10 @@
           <span class="status-chip__dot"></span>
           กลุ่มรันอยู่ <span id="chip-group-running">0</span>
         </span>
+        <span class="status-chip status-chip--processing">
+          <i class="bi bi-camera-video"></i>
+          กล้องรันอยู่ <span id="chip-camera-running">0</span>
+        </span>
         <span class="status-chip status-chip--page">
           <i class="bi bi-layers"></i>
           Page รันอยู่ <span id="chip-page-running">0</span>
@@ -117,6 +121,94 @@
         <p class="metric-card__value" id="metric-pages">0</p>
         <p class="metric-card__meta">กำลังรัน <span id="metric-pages-running">0</span> งาน</p>
       </div>
+    </div>
+  </section>
+
+  <section class="dashboard__panel dashboard__panel--wide">
+    <div class="panel-header">
+      <div>
+        <h2 class="panel-title">ROI และโมดูลที่ใช้งาน</h2>
+        <p class="panel-subtitle">สรุปจำนวน ROI ทั้งหมด โมดูลที่ทำงานอยู่ และประสิทธิภาพการประมวลผลล่าสุด</p>
+      </div>
+    </div>
+    <div class="roi-overview">
+      <div class="roi-overview__stats">
+        <div class="roi-stat">
+          <p class="roi-stat__label">ROI ทั้งหมด</p>
+          <p class="roi-stat__value" id="roi-total-count">0</p>
+          <p class="roi-stat__meta">รวมทุกแหล่งสัญญาณ</p>
+        </div>
+        <div class="roi-stat">
+          <p class="roi-stat__label">โมดูลที่ใช้งาน</p>
+          <p class="roi-stat__value" id="roi-module-count">0</p>
+          <p class="roi-stat__meta">โมดูลที่แตกต่างกัน</p>
+        </div>
+        <div class="roi-stat">
+          <p class="roi-stat__label">แหล่งสัญญาณมี ROI</p>
+          <p class="roi-stat__value" id="roi-source-count">0</p>
+          <p class="roi-stat__meta">กล้องหรือ Page ที่ตั้งค่าไว้</p>
+        </div>
+        <div class="roi-stat">
+          <p class="roi-stat__label">กล้องรัน Inference</p>
+          <p class="roi-stat__value" id="roi-running-count">0</p>
+          <p class="roi-stat__meta">ออนไลน์ในระบบ</p>
+        </div>
+      </div>
+      <div class="roi-overview__body">
+        <div class="roi-overview__modules">
+          <h3 class="roi-overview__title">โมดูลที่กำลังใช้งาน</h3>
+          <div class="roi-module-list" id="roi-module-list">
+            <div class="roi-module-list__empty">ยังไม่มีการกำหนด ROI</div>
+          </div>
+        </div>
+        <div class="roi-overview__performance">
+          <h3 class="roi-overview__title">เวลาในการประมวลผลของโมดูล</h3>
+          <div class="performance-cards">
+            <div class="performance-card performance-card--fast">
+              <p class="performance-card__label">เร็วที่สุด</p>
+              <h4 class="performance-card__title" id="module-fastest-name">-</h4>
+              <p class="performance-card__value" id="module-fastest-duration">-</p>
+              <p class="performance-card__meta" id="module-fastest-meta">รอข้อมูล</p>
+            </div>
+            <div class="performance-card performance-card--slow">
+              <p class="performance-card__label">ช้าที่สุด</p>
+              <h4 class="performance-card__title" id="module-slowest-name">-</h4>
+              <p class="performance-card__value" id="module-slowest-duration">-</p>
+              <p class="performance-card__meta" id="module-slowest-meta">รอข้อมูล</p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <section class="dashboard__panel dashboard__panel--wide">
+    <div class="panel-header">
+      <div>
+        <h2 class="panel-title">ภาพรวม ROI ต่อแหล่งสัญญาณ</h2>
+        <p class="panel-subtitle">ตรวจสอบโมดูลที่ใช้ร่วมกับเวลาประมวลผลจริง เทียบกับ Interval ที่ตั้งไว้</p>
+      </div>
+    </div>
+    <div class="table-responsive dashboard__table-wrapper dashboard__table-wrapper--compact">
+      <table class="table align-middle table-hover" id="roi-source-table">
+        <thead>
+          <tr>
+            <th>แหล่งสัญญาณ</th>
+            <th>กลุ่ม</th>
+            <th>จำนวน ROI</th>
+            <th>โมดูล</th>
+            <th>เวลาเฉลี่ย</th>
+            <th>สูงสุด</th>
+            <th>Interval</th>
+            <th>สถานะ</th>
+          </tr>
+        </thead>
+        <tbody id="roi-source-table-body">
+          <tr>
+            <td colspan="8" class="text-center text-muted py-4">ยังไม่มีการตั้งค่า ROI</td>
+          </tr>
+        </tbody>
+      </table>
     </div>
   </section>
 

--- a/templates/home.html
+++ b/templates/home.html
@@ -57,73 +57,6 @@
     </div>
   </div>
 
-  <section class="dashboard__metrics">
-    <div class="metric-card" data-metric="total">
-      <div class="metric-card__icon bg-primary text-white"><i class="bi bi-camera-video"></i></div>
-      <div class="metric-card__body">
-        <p class="metric-card__label">จำนวนกล้องทั้งหมด</p>
-        <p class="metric-card__value" id="metric-total">0</p>
-        <p class="metric-card__meta">ROI เฝ้าระวัง <span id="metric-total-roi">0</span> โซน</p>
-      </div>
-    </div>
-    <div class="metric-card" data-metric="online">
-      <div class="metric-card__icon bg-success text-white"><i class="bi bi-wifi"></i></div>
-      <div class="metric-card__body">
-        <p class="metric-card__label">กล้องออนไลน์</p>
-        <p class="metric-card__value" id="metric-online">0</p>
-        <p class="metric-card__meta">คิดเป็น <span id="metric-online-rate-meta">0%</span></p>
-      </div>
-    </div>
-    <div class="metric-card" data-metric="running">
-      <div class="metric-card__icon bg-warning text-dark"><i class="bi bi-cpu"></i></div>
-      <div class="metric-card__body">
-        <p class="metric-card__label">Inference ที่กำลังรัน</p>
-        <p class="metric-card__value" id="metric-running">0</p>
-        <p class="metric-card__meta">โหลดระบบ <span id="metric-running-ratio">0%</span></p>
-      </div>
-    </div>
-    <div class="metric-card" data-metric="groups">
-      <div class="metric-card__icon bg-secondary text-white"><i class="bi bi-diagram-3"></i></div>
-      <div class="metric-card__body">
-        <p class="metric-card__label">จำนวนกลุ่ม</p>
-        <p class="metric-card__value" id="metric-groups">0</p>
-        <p class="metric-card__meta">รันอยู่ <span id="metric-groups-running">0</span> กลุ่ม</p>
-      </div>
-    </div>
-    <div class="metric-card" data-metric="alerts">
-      <div class="metric-card__icon bg-danger text-white"><i class="bi bi-bell"></i></div>
-      <div class="metric-card__body">
-        <p class="metric-card__label">แจ้งเตือนชั่วโมงล่าสุด</p>
-        <p class="metric-card__value" id="metric-alerts">0</p>
-        <p class="metric-card__meta">เฉลี่ย <span id="metric-alert-density">0.00</span> / กล้อง</p>
-      </div>
-    </div>
-    <div class="metric-card" data-metric="interval">
-      <div class="metric-card__icon bg-info text-dark"><i class="bi bi-stopwatch"></i></div>
-      <div class="metric-card__body">
-        <p class="metric-card__label">Interval เฉลี่ย (วินาที)</p>
-        <p class="metric-card__value" id="metric-interval">0.0</p>
-        <p class="metric-card__meta">เร็วที่สุด <span id="metric-min-interval">-</span></p>
-      </div>
-    </div>
-    <div class="metric-card" data-metric="fps">
-      <div class="metric-card__icon bg-dark text-white"><i class="bi bi-graph-up"></i></div>
-      <div class="metric-card__body">
-        <p class="metric-card__label">FPS เฉลี่ย</p>
-        <p class="metric-card__value" id="metric-fps">0.0</p>
-        <p class="metric-card__meta">สูงสุด <span id="metric-max-fps">-</span></p>
-      </div>
-    </div>
-    <div class="metric-card" data-metric="pages">
-      <div class="metric-card__icon bg-primary-subtle text-primary"><i class="bi bi-journal-text"></i></div>
-      <div class="metric-card__body">
-        <p class="metric-card__label">งาน Page ทั้งหมด</p>
-        <p class="metric-card__value" id="metric-pages">0</p>
-        <p class="metric-card__meta">กำลังรัน <span id="metric-pages-running">0</span> งาน</p>
-      </div>
-    </div>
-  </section>
-
   <section class="dashboard__panel dashboard__panel--wide">
     <div class="panel-header">
       <div>
@@ -341,7 +274,7 @@
       </div>
     </section>
 
-    <section class="dashboard__panel">
+    <section class="dashboard__panel dashboard__panel--full">
       <div class="panel-header">
         <div>
           <h2 class="panel-title">สรุปแจ้งเตือน</h2>
@@ -352,7 +285,7 @@
         <div class="alert-summary__empty">ยังไม่มีแจ้งเตือน</div>
       </div>
     </section>
-    <section class="dashboard__panel">
+    <section class="dashboard__panel dashboard__panel--full dashboard__panel--scroll">
       <div class="panel-header">
         <div>
           <h2 class="panel-title">แจ้งเตือนล่าสุด</h2>


### PR DESCRIPTION
## Summary
- เพิ่มข้อมูล ROI, โมดูลที่ใช้งาน และประสิทธิภาพการประมวลผลลงใน payload ของ `/api/dashboard`
- ปรับหน้าแดชบอร์ดให้แสดงสถิติ ROI, โมดูลยอดนิยม, เวลาเร็ว/ช้า และตารางสถานะแต่ละแหล่งสัญญาณ
- อัปเดตสคริปต์แดชบอร์ดเพื่อเรนเดอร์การ์ดโมดูล ตาราง ROI และการตีความสถานะ interval

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68cfa2384580832b8913f5db7dc9c7f4