### PR TITLE
Show inference ID in cam row badge and refine dashboard alerts layout

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -807,7 +807,7 @@ main.app-main {
 
 .dashboard__content {
   display: grid;
-  grid-template-columns: minmax(0, 1fr) 340px;
+  grid-template-columns: minmax(0, 1fr);
   gap: clamp(1.5rem, 2vw, 2rem);
   align-items: start;
 }
@@ -968,10 +968,6 @@ main.app-main {
 }
 
 @media (max-width: 1200px) {
-  .dashboard__content {
-    grid-template-columns: 1fr;
-  }
-
   .dashboard__panel--wide {
     grid-column: 1 / -1;
   }

--- a/templates/home.html
+++ b/templates/home.html
@@ -53,73 +53,6 @@
     </div>
   </div>
 
-  <section class="dashboard__metrics">
-    <div class="metric-card" data-metric="total">
-      <div class="metric-card__icon bg-primary text-white"><i class="bi bi-camera-video"></i></div>
-      <div class="metric-card__body">
-        <p class="metric-card__label">จำนวนกล้องทั้งหมด</p>
-        <p class="metric-card__value" id="metric-total">0</p>
-        <p class="metric-card__meta">ROI เฝ้าระวัง <span id="metric-total-roi">0</span> โซน</p>
-      </div>
-    </div>
-    <div class="metric-card" data-metric="online">
-      <div class="metric-card__icon bg-success text-white"><i class="bi bi-wifi"></i></div>
-      <div class="metric-card__body">
-        <p class="metric-card__label">กล้องออนไลน์</p>
-        <p class="metric-card__value" id="metric-online">0</p>
-        <p class="metric-card__meta">คิดเป็น <span id="metric-online-rate-meta">0%</span></p>
-      </div>
-    </div>
-    <div class="metric-card" data-metric="running">
-      <div class="metric-card__icon bg-warning text-dark"><i class="bi bi-cpu"></i></div>
-      <div class="metric-card__body">
-        <p class="metric-card__label">Inference ที่กำลังรัน</p>
-        <p class="metric-card__value" id="metric-running">0</p>
-        <p class="metric-card__meta">โหลดระบบ <span id="metric-running-ratio">0%</span></p>
-      </div>
-    </div>
-    <div class="metric-card" data-metric="groups">
-      <div class="metric-card__icon bg-secondary text-white"><i class="bi bi-diagram-3"></i></div>
-      <div class="metric-card__body">
-        <p class="metric-card__label">จำนวนกลุ่ม</p>
-        <p class="metric-card__value" id="metric-groups">0</p>
-        <p class="metric-card__meta">รันอยู่ <span id="metric-groups-running">0</span> กลุ่ม</p>
-      </div>
-    </div>
-    <div class="metric-card" data-metric="alerts">
-      <div class="metric-card__icon bg-danger text-white"><i class="bi bi-bell"></i></div>
-      <div class="metric-card__body">
-        <p class="metric-card__label">แจ้งเตือนชั่วโมงล่าสุด</p>
-        <p class="metric-card__value" id="metric-alerts">0</p>
-        <p class="metric-card__meta">เฉลี่ย <span id="metric-alert-density">0.00</span> / กล้อง</p>
-      </div>
-    </div>
-    <div class="metric-card" data-metric="interval">
-      <div class="metric-card__icon bg-info text-dark"><i class="bi bi-stopwatch"></i></div>
-      <div class="metric-card__body">
-        <p class="metric-card__label">Interval เฉลี่ย (วินาที)</p>
-        <p class="metric-card__value" id="metric-interval">0.0</p>
-        <p class="metric-card__meta">เร็วที่สุด <span id="metric-min-interval">-</span></p>
-      </div>
-    </div>
-    <div class="metric-card" data-metric="fps">
-      <div class="metric-card__icon bg-dark text-white"><i class="bi bi-graph-up"></i></div>
-      <div class="metric-card__body">
-        <p class="metric-card__label">FPS เฉลี่ย</p>
-        <p class="metric-card__value" id="metric-fps">0.0</p>
-        <p class="metric-card__meta">สูงสุด <span id="metric-max-fps">-</span></p>
-      </div>
-    </div>
-    <div class="metric-card" data-metric="pages">
-      <div class="metric-card__icon bg-primary-subtle text-primary"><i class="bi bi-journal-text"></i></div>
-      <div class="metric-card__body">
-        <p class="metric-card__label">งาน Page ทั้งหมด</p>
-        <p class="metric-card__value" id="metric-pages">0</p>
-        <p class="metric-card__meta">กำลังรัน <span id="metric-pages-running">0</span> งาน</p>
-      </div>
-    </div>
-  </section>
-
   <section class="dashboard__insights">
     <article class="insight-card">
       <div class="insight-card__header">
@@ -249,31 +182,29 @@
       </div>
     </section>
 
-    <aside class="dashboard__sidebar">
-      <section class="dashboard__panel">
-        <div class="panel-header">
-          <div>
-            <h2 class="panel-title">สรุปแจ้งเตือน</h2>
-            <p class="panel-subtitle">ดูภาพรวมเหตุการณ์ที่เกิดขึ้นบ่อยและเวลาอัปเดตล่าสุด</p>
-          </div>
+    <section class="dashboard__panel dashboard__panel--wide">
+      <div class="panel-header">
+        <div>
+          <h2 class="panel-title">สรุปแจ้งเตือน</h2>
+          <p class="panel-subtitle">ดูภาพรวมเหตุการณ์ที่เกิดขึ้นบ่อยและเวลาอัปเดตล่าสุด</p>
         </div>
-        <div class="alert-summary" id="alert-summary">
-          <div class="alert-summary__empty">ยังไม่มีแจ้งเตือน</div>
-        </div>
-      </section>
-      <section class="dashboard__panel">
-        <div class="panel-header">
-          <div>
-            <h2 class="panel-title">แจ้งเตือนล่าสุด</h2>
-            <p class="panel-subtitle">ผลลัพธ์ที่ระบบบันทึกไว้ล่าสุด (สูงสุด 20 รายการ)</p>
-          </div>
-        </div>
-        <ul class="timeline" id="alert-timeline">
-          <li class="timeline__empty">ยังไม่มีแจ้งเตือน</li>
-        </ul>
-      </section>
+      </div>
+      <div class="alert-summary" id="alert-summary">
+        <div class="alert-summary__empty">ยังไม่มีแจ้งเตือน</div>
+      </div>
+    </section>
 
-    </aside>
+    <section class="dashboard__panel dashboard__panel--wide">
+      <div class="panel-header">
+        <div>
+          <h2 class="panel-title">แจ้งเตือนล่าสุด</h2>
+          <p class="panel-subtitle">ผลลัพธ์ที่ระบบบันทึกไว้ล่าสุด (สูงสุด 20 รายการ)</p>
+        </div>
+      </div>
+      <ul class="timeline" id="alert-timeline">
+        <li class="timeline__empty">ยังไม่มีแจ้งเตือน</li>
+      </ul>
+    </section>
   </div>
 
   <section class="dashboard__panel">

--- a/templates/partials/inference_content.html
+++ b/templates/partials/inference_content.html
@@ -784,6 +784,7 @@
           row.classList.add('mt-2');
       }
       row.dataset.cellId = cellId;
+      row.dataset.rowLabel = camId;
       row.innerHTML = `
         <div class="d-flex align-items-center justify-content-between flex-wrap gap-2 mb-3">
           <div>

--- a/templates/partials/inference_page_content.html
+++ b/templates/partials/inference_page_content.html
@@ -772,6 +772,7 @@
         row.classList.add('mt-2');
       }
       row.dataset.cellId = cellId;
+      row.dataset.rowLabel = camId;
       row.innerHTML = `
         <div class="d-flex align-items-center justify-content-between flex-wrap gap-2 mb-3">
           <div>


### PR DESCRIPTION
## Summary
- set the cam row badge data attribute to the inference ID for dynamic inference groups
- apply the same ID badge update on the page inference view so both pages display the job identifier
- remove the dashboard metric card section and present the alert summary and latest alerts as full-width rows for better readability

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cfa42b9020832ba3c7c249223bcf26