### PR TITLE
Translate top navigation menu to English

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="th">
+<html lang="en">
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
@@ -29,21 +29,21 @@
       <div class="collapse navbar-collapse" id="navbarNav">
         <ul class="navbar-nav ms-auto mb-2 mb-lg-0 align-items-lg-center">
           <li class="nav-item">
-            <a href="/home" class="nav-link" data-bs-toggle="tooltip" title="หน้าแรก">
+            <a href="/home" class="nav-link" data-bs-toggle="tooltip" title="Home">
               <i class="bi bi-speedometer2 me-2"></i>
-              <span>หน้าแรก</span>
+              <span>Home</span>
             </a>
           </li>
           <li class="nav-item">
-            <a href="/docs" class="nav-link" data-bs-toggle="tooltip" title="คู่มือการใช้งาน">
+            <a href="/docs" class="nav-link" data-bs-toggle="tooltip" title="Documentation">
               <i class="bi bi-journal-text me-2"></i>
-              <span>คู่มือ</span>
+              <span>Documentation</span>
             </a>
           </li>
           <li class="nav-item">
             <a href="/create_source" class="nav-link" data-bs-toggle="tooltip" title="Create Source">
               <i class="bi bi-hdd-network me-2"></i>
-              <span>สร้างแหล่งวิดีโอ</span>
+              <span>Create Source</span>
             </a>
           </li>
           <li class="nav-item">


### PR DESCRIPTION
## Summary
- update the base layout so the HTML language attribute is English
- translate the top navigation menu tooltips and labels to English

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cfae315854832ba05c88e8fcaedd1c