### PR TITLE
Enhance dashboard ROI insights display

### DIFF
--- a/app.py
+++ b/app.py
@@ -653,6 +653,30 @@ def build_dashboard_payload() -> dict[str, Any]:
             if ts >= float(module_entry.get("latest_timestamp", 0.0) or 0.0):
                 module_entry["latest_duration"] = duration_val
                 module_entry["latest_timestamp"] = ts
+                roi_identifier = result.get("id")
+                roi_name = result.get("name")
+                source_name = notif.get("source")
+                cam_identifier = notif.get("cam_id")
+                module_entry["latest_roi_id"] = (
+                    str(roi_identifier)
+                    if roi_identifier is not None and str(roi_identifier)
+                    else None
+                )
+                module_entry["latest_roi_name"] = (
+                    str(roi_name)
+                    if roi_name is not None and str(roi_name).strip()
+                    else None
+                )
+                module_entry["latest_source"] = (
+                    str(source_name)
+                    if source_name is not None and str(source_name).strip()
+                    else None
+                )
+                module_entry["latest_cam_id"] = (
+                    str(cam_identifier)
+                    if cam_identifier is not None and str(cam_identifier)
+                    else None
+                )
         cam_id = notif.get("cam_id")
         if cam_id and total_duration > 0:
             source_entry = source_duration_stats.setdefault(
@@ -907,6 +931,10 @@ def build_dashboard_payload() -> dict[str, Any]:
                 "sample_count": duration_count,
                 "latest_duration": durations.get("latest_duration"),
                 "latest_timestamp": durations.get("latest_timestamp"),
+                "latest_roi_id": durations.get("latest_roi_id"),
+                "latest_roi_name": durations.get("latest_roi_name"),
+                "latest_cam_id": durations.get("latest_cam_id"),
+                "latest_source": durations.get("latest_source"),
             }
         )
 

--- a/static/js/dashboard.js
+++ b/static/js/dashboard.js
@@ -144,6 +144,38 @@ function formatSecondsWithUnit(value) {
   return fixed !== null ? `${fixed} วินาที` : null;
 }
 
+function formatRoiDetail(entry) {
+  if (!entry) {
+    return 'รอข้อมูล ROI';
+  }
+  const roiNameRaw = entry?.latest_roi_name;
+  const roiIdRaw = entry?.latest_roi_id;
+  const sourceRaw = entry?.latest_source;
+  const camRaw = entry?.latest_cam_id;
+
+  const roiName = typeof roiNameRaw === 'string' ? roiNameRaw.trim() : '';
+  const roiId =
+    roiIdRaw !== null && roiIdRaw !== undefined
+      ? String(roiIdRaw).trim()
+      : '';
+  const source = typeof sourceRaw === 'string' ? sourceRaw.trim() : '';
+  const camId =
+    camRaw !== null && camRaw !== undefined ? String(camRaw).trim() : '';
+
+  const roiLabel = roiName || (roiId ? `ROI ${roiId}` : '');
+  const locationLabel = source || (camId ? `กล้อง ${camId}` : '');
+
+  const parts = [];
+  if (roiLabel) {
+    parts.push(roiLabel);
+  }
+  if (locationLabel) {
+    parts.push(locationLabel);
+  }
+
+  return parts.length ? parts.join(' · ') : 'รอข้อมูล ROI';
+}
+
 function calculateCameraInsights(cameras = []) {
   return cameras.reduce((acc, camera) => {
     const roiCount = Number(camera?.roi_count);
@@ -272,6 +304,7 @@ function updateModulePerformance(performance = {}) {
     'module-fastest-duration',
     fastestDuration != null ? formatSecondsWithUnit(fastestDuration) || '-' : '-',
   );
+  setElementText('module-fastest-roi', formatRoiDetail(fastest));
   setElementText('module-fastest-meta', fastestMeta);
 
   setElementText('module-slowest-name', slowest?.name || '-');
@@ -280,6 +313,7 @@ function updateModulePerformance(performance = {}) {
     'module-slowest-duration',
     slowestDuration != null ? formatSecondsWithUnit(slowestDuration) || '-' : '-',
   );
+  setElementText('module-slowest-roi', formatRoiDetail(slowest));
   setElementText('module-slowest-meta', slowestMeta);
 }
 
@@ -389,6 +423,8 @@ function updateRoiSourceTable(details = []) {
     const latestDuration =
       detail?.latest_duration != null ? detail.latest_duration : detail?.average_duration;
     avgCell.textContent = formatSeconds(latestDuration);
+    avgCell.title =
+      'เวลาที่ใช้ในการ inference ครบทุก ROI ในเฟรมล่าสุดของแหล่งนี้';
 
     const maxCell = document.createElement('td');
     maxCell.textContent = formatSeconds(detail?.max_duration);

--- a/templates/home.html
+++ b/templates/home.html
@@ -155,12 +155,14 @@
               <p class="performance-card__label">เร็วที่สุด</p>
               <h4 class="performance-card__title" id="module-fastest-name">-</h4>
               <p class="performance-card__value" id="module-fastest-duration">-</p>
+              <p class="performance-card__meta" id="module-fastest-roi">รอข้อมูล ROI</p>
               <p class="performance-card__meta" id="module-fastest-meta">รอข้อมูล</p>
             </div>
             <div class="performance-card performance-card--slow">
               <p class="performance-card__label">ช้าที่สุด</p>
               <h4 class="performance-card__title" id="module-slowest-name">-</h4>
               <p class="performance-card__value" id="module-slowest-duration">-</p>
+              <p class="performance-card__meta" id="module-slowest-roi">รอข้อมูล ROI</p>
               <p class="performance-card__meta" id="module-slowest-meta">รอข้อมูล</p>
             </div>
           </div>
@@ -184,7 +186,7 @@
             <th>กลุ่ม</th>
             <th>จำนวน ROI</th>
             <th>โมดูล</th>
-            <th>เวลารอบล่าสุด</th>
+            <th>เวลารอบล่าสุด<br><small class="text-muted">ครบทุก ROI ต่อเฟรม</small></th>
             <th>สูงสุด</th>
             <th>Interval</th>
             <th>สถานะ</th>


### PR DESCRIPTION
## Summary
- track latest ROI metadata for each module so the dashboard can show context for fastest and slowest results
- surface ROI names on the performance cards and clarify the latest round column represents processing all ROIs per frame
- add a tooltip on the latest-round column to explain the aggregate inference duration

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d0080cc6f8832bbf7ba136bb81cfe2