### PR TITLE
ปรับ UI ROI overview ตามรอบเฟรมล่าสุด

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -545,6 +545,22 @@ main.app-main {
   font-size: 0.85rem;
 }
 
+.performance-card__meta--detail {
+  font-weight: 600;
+}
+
+.performance-card__meta--frame {
+  font-size: 0.78rem;
+  opacity: 0.85;
+}
+
+.performance-card--fast .performance-card__meta--detail,
+.performance-card--fast .performance-card__meta--frame,
+.performance-card--slow .performance-card__meta--detail,
+.performance-card--slow .performance-card__meta--frame {
+  color: inherit;
+}
+
 .module-badge-group {
   display: flex;
   flex-wrap: wrap;
@@ -622,6 +638,21 @@ main.app-main {
   margin: 0;
   font-size: 0.78rem;
   color: rgba(15, 23, 42, 0.55);
+}
+
+.roi-source-duration {
+  display: flex;
+  flex-direction: column;
+  gap: 0.15rem;
+}
+
+.roi-source-duration__value {
+  font-weight: 600;
+}
+
+.roi-source-duration__meta {
+  font-size: 0.75rem;
+  color: rgba(15, 23, 42, 0.6);
 }
 
 @media (max-width: 1200px) {

--- a/templates/home.html
+++ b/templates/home.html
@@ -155,15 +155,15 @@
               <p class="performance-card__label">เร็วที่สุด</p>
               <h4 class="performance-card__title" id="module-fastest-name">-</h4>
               <p class="performance-card__value" id="module-fastest-duration">-</p>
-              <p class="performance-card__meta" id="module-fastest-roi">รอข้อมูล ROI</p>
-              <p class="performance-card__meta" id="module-fastest-meta">รอข้อมูล</p>
+              <p class="performance-card__meta performance-card__meta--detail" id="module-fastest-roi">รอข้อมูล ROI</p>
+              <p class="performance-card__meta performance-card__meta--frame" id="module-fastest-meta">รอข้อมูล</p>
             </div>
             <div class="performance-card performance-card--slow">
               <p class="performance-card__label">ช้าที่สุด</p>
               <h4 class="performance-card__title" id="module-slowest-name">-</h4>
               <p class="performance-card__value" id="module-slowest-duration">-</p>
-              <p class="performance-card__meta" id="module-slowest-roi">รอข้อมูล ROI</p>
-              <p class="performance-card__meta" id="module-slowest-meta">รอข้อมูล</p>
+              <p class="performance-card__meta performance-card__meta--detail" id="module-slowest-roi">รอข้อมูล ROI</p>
+              <p class="performance-card__meta performance-card__meta--frame" id="module-slowest-meta">รอข้อมูล</p>
             </div>
           </div>
         </div>
@@ -186,7 +186,7 @@
             <th>กลุ่ม</th>
             <th>จำนวน ROI</th>
             <th>โมดูล</th>
-            <th>เวลารอบล่าสุด<br><small class="text-muted">ครบทุก ROI ต่อเฟรม ตั้งแต่ ROI แรกถึง ROI สุดท้าย</small></th>
+            <th>เวลารอบล่าสุด<br><small class="text-muted">เวลาของเฟรมล่าสุดที่ส่งผลครบทุก ROI ตั้งแต่ ROI แรกถึง ROI สุดท้าย</small></th>
             <th>สูงสุด</th>
             <th>Interval</th>
             <th>สถานะ</th>


### PR DESCRIPTION
## Summary
- แสดงระยะเวลาเฟรมล่าสุดของแต่ละแหล่งสัญญาณพร้อมเวลาบันทึกที่อัปเดตทุกเฟรม
- เพิ่มข้อมูลรอบเฟรมล่าสุดให้การ์ดเร็วที่สุด/ช้าที่สุด พร้อมโชว์ ROI และโมดูลที่เกี่ยวข้อง
- ปรับสไตล์ให้รองรับรายละเอียดใหม่ของการ์ดและตาราง ROI

## Testing
- pytest tests/test_inference_routes.py

------
https://chatgpt.com/codex/tasks/task_e_68d01a2a0e9c832b81e24d113f0c74da