### PR TITLE
Refine ROI overview latest run timing display

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -655,6 +655,16 @@ main.app-main {
   color: rgba(15, 23, 42, 0.6);
 }
 
+.roi-source-duration__meta--stale {
+  color: #b45309;
+  font-weight: 500;
+}
+
+.roi-source-duration__meta--critical {
+  color: #dc2626;
+  font-weight: 600;
+}
+
 @media (max-width: 1200px) {
   .roi-overview__body {
     grid-template-columns: 1fr;


### PR DESCRIPTION
## Summary
- show relative timestamps for the latest ROI cycle and enrich tooltip information on the dashboard table
- flag stale or overdue ROI updates using interval-aware thresholds
- add styling for the stale/critical meta indicators in the ROI overview

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d021d6141c832ba0a86e697c92efb1