### PR TITLE
Fix draining order to keep websocket stop sentinel

### DIFF
--- a/app.py
+++ b/app.py
@@ -2135,9 +2135,11 @@ async def stop_camera_task(
         if queue_dict is not None:
             queue = queue_dict.pop(cam_id, None)
             if queue is not None:
+                # Drain stale frames before sending the stop sentinel so
+                # websocket consumers still observe the ``None`` item.
+                _drain_queue(queue)
                 with contextlib.suppress(Exception):
                     await asyncio.wait_for(queue.put(None), timeout=0.2)
-                _drain_queue(queue)
 
         inf_task = inference_tasks.get(cam_id)
         roi_task = roi_tasks.get(cam_id)


### PR DESCRIPTION
## Summary
- drain camera queues before enqueuing the stop sentinel so websocket consumers receive the None item

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d3566cb534832b9d666a53d6c52651