### PR TITLE
Fix inference restart source selection and ROI sync

### DIFF
--- a/app.py
+++ b/app.py
@@ -2857,7 +2857,16 @@ async def stop_roi_stream(cam_id: str):
 @app.route('/inference_status/<string:cam_id>', methods=["GET"])
 async def inference_status(cam_id: str):
     running = inference_tasks.get(cam_id) is not None and not inference_tasks[cam_id].done()
-    return jsonify({"running": running, "cam_id": cam_id})
+    source = active_sources.get(cam_id, "")
+    group = inference_groups.get(cam_id)
+    if not isinstance(group, str):
+        group = ""
+    return jsonify({
+        "running": running,
+        "cam_id": cam_id,
+        "source": source,
+        "group": group,
+    })
 
 
 @app.route('/roi_stream_status/<string:cam_id>', methods=["GET"])

--- a/templates/partials/inference_content.html
+++ b/templates/partials/inference_content.html
@@ -651,7 +651,8 @@
             } else {
                 showAlert('Camera started', 'success');
             }
-            startLogUpdates(cfg.name);
+            const logSourceName = cfg.name || name;
+            startLogUpdates(logSourceName);
             setRunningUI();
         }
 
@@ -740,9 +741,31 @@
         }
 
         async function checkStatus() {
-            const name = sourceSelect.value;
+            let name = sourceSelect.value || '';
             const res = await fetchWithStatus(`/inference_status/${cam}`);
             const data = await res.json();
+            const statusSource = typeof data.source === 'string' ? data.source : '';
+            const statusGroup = typeof data.group === 'string' ? data.group : '';
+            if (statusSource) {
+                const options = Array.from(sourceSelect.options || []);
+                const hasOption = options.some(opt => opt.value === statusSource);
+                if (!hasOption) {
+                    const opt = document.createElement('option');
+                    opt.value = statusSource;
+                    opt.textContent = statusSource;
+                    sourceSelect.appendChild(opt);
+                }
+                if (sourceSelect.value !== statusSource) {
+                    sourceSelect.value = statusSource;
+                    storeValue('source', statusSource);
+                    updateHeaderSourceLabel();
+                }
+            }
+            if (!name && statusSource) {
+                name = statusSource;
+                storeValue('source', statusSource);
+                updateHeaderSourceLabel();
+            }
             if (data.running && name) {
                 openSocket();
                 const cfgRes = await fetchWithStatus(`/source_config?name=${encodeURIComponent(name)}`);
@@ -755,8 +778,9 @@
                 const roiData = await roiRes.json();
                 allRois = roiData.rois || [];
                 const roiList = allRois.filter(r => (r.type ?? 'roi') === 'roi');
-                const activeGroup = loadGroupOptions(roiList);
-                const groupToUse = activeGroup || '';
+                const normalizedStatusGroup = typeof statusGroup === 'string' ? statusGroup : '';
+                const activeGroup = loadGroupOptions(roiList, normalizedStatusGroup);
+                const groupToUse = (normalizedStatusGroup || activeGroup || '').trim();
                 if (groupToUse === 'all') {
                     rois = roiList;
                 } else if (groupToUse) {
@@ -771,13 +795,15 @@
                         updateRoiModuleLabel(r.id);
                     }
                 });
+                lastActiveGroup = groupToUse || '';
                 if (roiSocket) {
                     roiSocket.close();
                     roiSocket = null;
                 }
                 openRoiSocket();
                 stopLogUpdates();
-                startLogUpdates(cfg.name);
+                const logSourceName = cfg.name || statusSource || name;
+                startLogUpdates(logSourceName);
                 setRunningUI();
                 running = true;
             } else {

--- a/templates/partials/inference_page_content.html
+++ b/templates/partials/inference_page_content.html
@@ -655,7 +655,8 @@
         } else {
           showAlert('Camera started', 'success');
         }
-        startLogUpdates(cfg.name);
+        const logSourceName = cfg.name || name;
+        startLogUpdates(logSourceName);
         setRunningUI();
       }
 
@@ -749,9 +750,32 @@
       }
 
       async function checkStatus() {
-        const name = sourceSelect.value;
+        let name = sourceSelect.value || '';
         const res = await fetchWithStatus(`/inference_status/${cam}`);
         const data = await res.json();
+        const statusSource = typeof data.source === 'string' ? data.source : '';
+        const statusGroupRaw = typeof data.group === 'string' ? data.group : '';
+        const normalizedStatusGroup = normalizeGroupName(statusGroupRaw);
+        if (statusSource) {
+          const options = Array.from(sourceSelect.options || []);
+          const hasOption = options.some(opt => opt.value === statusSource);
+          if (!hasOption) {
+            const opt = document.createElement('option');
+            opt.value = statusSource;
+            opt.textContent = statusSource;
+            sourceSelect.appendChild(opt);
+          }
+          if (sourceSelect.value !== statusSource) {
+            sourceSelect.value = statusSource;
+            storeValue('source', statusSource);
+            updateHeaderSourceLabel();
+          }
+        }
+        if (!name && statusSource) {
+          name = statusSource;
+          storeValue('source', statusSource);
+          updateHeaderSourceLabel();
+        }
         if (data.running && name) {
           openSocket();
           const cfgRes = await fetchWithStatus(`/source_config?name=${encodeURIComponent(name)}`);
@@ -766,6 +790,12 @@
           allRois = roiEntries;
           rebuildRoiGroupIndex(roiEntries);
           resetScoreboard();
+          if (normalizedStatusGroup) {
+            setActiveGroup(normalizedStatusGroup);
+            if (pageNameEl) {
+              pageNameEl.textContent = normalizedStatusGroup;
+            }
+          }
           const hasAnyRoiEntry = roiEntries.length > 0;
           if (roiSocket) {
             roiSocket.close();
@@ -775,7 +805,8 @@
             openRoiSocket();
           }
           stopLogUpdates();
-          startLogUpdates(cfg.name);
+          const logSourceName = cfg.name || statusSource || name;
+          startLogUpdates(logSourceName);
           setRunningUI();
           running = true;
         } else {


### PR DESCRIPTION
## Summary
- expose the active source and group from `/inference_status` so the UI can recover correct state after a restart
- update the inference group and page controllers to sync their source/group selectors with the running session and rebuild ROI views accordingly
- ensure log polling falls back to a sensible source name when starting or resuming inference

## Testing
- pytest *(fails: tests/test_rapid_ocr_result_parsing.py::test_rapid_ocr_accepts_dict_results, tests/test_rapid_ocr_result_parsing.py::test_rapid_ocr_accepts_object_with_text, tests/test_rapid_ocr_result_parsing.py::test_rapid_ocr_accepts_object_with_txts)*

------
https://chatgpt.com/codex/tasks/task_e_68d6af9c6870832ba124d3015b716963