### PR TITLE
Fix RapidOCR result caching

### DIFF
--- a/inference_modules/rapid_ocr/custom.py
+++ b/inference_modules/rapid_ocr/custom.py
@@ -396,11 +396,12 @@ def _run_rec_only_async(frame, roi_id, save, source) -> str:
             if roi_id is not None
             else f"rec OCR result: {text}"
         )
-        with _last_ocr_lock:
-            last_ocr_results[roi_id] = text
     except Exception as e:
         logger.exception(f"roi_id={roi_id} rec OCR error: {e}")
         text = ""
+
+    with _last_ocr_lock:
+        last_ocr_results[roi_id] = text
 
     if save:
         base_dir = _data_sources_root / source if source else Path(__file__).resolve().parent
@@ -506,7 +507,8 @@ def process(
             last_ocr_times[roi_id] = current_time
         return _run_rec_only_async(frame, roi_id, save, source)
 
-    return None
+    with _last_ocr_lock:
+        return last_ocr_results.get(roi_id)
 
 
 def cleanup() -> None:


### PR DESCRIPTION
## Summary
- ensure RapidOCR rec-only runner always updates cached results even on errors
- return the most recent OCR text when skipping inference due to the interval

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d727946b3c832b8c8dc8042fd05210