### PR TITLE
Ensure OCR modules return cached result when interval not elapsed

### DIFF
--- a/inference_modules/base_ocr.py
+++ b/inference_modules/base_ocr.py
@@ -102,7 +102,9 @@ class BaseOCR:
             with self._last_ocr_lock:
                 self.last_ocr_results[roi_id] = text
             return text
-        return None
+
+        with self._last_ocr_lock:
+            return self.last_ocr_results.get(roi_id)
 
     def stop(self, roi_id) -> None:
         with self._last_ocr_lock:


### PR DESCRIPTION
## Summary
- return the last cached OCR output when BaseOCR skips execution because the interval has not elapsed
- extend the Tesseract OCR tests to cover the cached-result behaviour and track pytesseract invocations

## Testing
- pytest tests/test_tesseract_ocr.py

------
https://chatgpt.com/codex/tasks/task_e_68d74782fdf8832ba1a681e8696bc6a4