### PR TITLE
Remove ROI interval throttling from OCR modules

### DIFF
--- a/inference_modules/typhoon_ocr/custom.py
+++ b/inference_modules/typhoon_ocr/custom.py
@@ -24,8 +24,6 @@ _data_sources_root = Path(__file__).resolve().parents[2] / "data_sources"
 # โหลดโมเดล (ถ้ามี)
 # model = YOLOv8("data_sources/<your_source>/model.onnx")
 
-# ตัวแปรควบคุมเวลาเรียก OCR แยกตาม roi พร้อมตัวล็อกป้องกันการเข้าถึงพร้อมกัน
-last_ocr_times = {}
 last_ocr_results = {}
 _last_ocr_lock = threading.Lock()
 
@@ -37,7 +35,7 @@ def process(
     source="",
     cam_id: int | None = None,
 ):
-    """ประมวลผล ROI และเรียก OCR เมื่อเวลาห่างจากครั้งก่อน >= 2 วินาที
+    """ประมวลผล ROI และเรียก OCR ทุกเฟรม
     บันทึกรูปภาพแบบไม่บล็อกเมื่อระบุให้บันทึก"""
     logger = get_logger(MODULE_NAME, source)
 

--- a/tests/test_easy_ocr_cleanup.py
+++ b/tests/test_easy_ocr_cleanup.py
@@ -30,7 +30,6 @@ def test_cleanup_resets_state_and_allows_reuse(monkeypatch):
 
     custom.cleanup()
     assert custom._reader is None
-    assert custom.last_ocr_times == {}
     assert custom.last_ocr_results == {}
 
     custom.process([], roi_id="r2", source="src")

--- a/tests/test_rapid_ocr_cleanup.py
+++ b/tests/test_rapid_ocr_cleanup.py
@@ -10,7 +10,6 @@ from inference_modules import base_ocr
 def test_cleanup_resets_state_and_calls_gc(monkeypatch):
     ocr = RapidOCR()
     custom._reader = object()
-    custom.last_ocr_times["roi"] = 1
     custom.last_ocr_results["roi"] = "text"
 
     called = False
@@ -25,7 +24,6 @@ def test_cleanup_resets_state_and_calls_gc(monkeypatch):
     ocr.cleanup()
 
     assert custom._reader is None
-    assert custom.last_ocr_times == {}
     assert custom.last_ocr_results == {}
 
     assert called


### PR DESCRIPTION
## Summary
- remove per-ROI interval throttling so OCR modules run each frame and persist latest results
- update RapidOCR fallbacks and cleanup tests after removing ROI timing state

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d74ae727b0832b9b80000270874b34