### PR TITLE
Fix RapidOCR text extraction for nested result keys

### DIFF
--- a/inference_modules/rapid_ocr/custom.py
+++ b/inference_modules/rapid_ocr/custom.py
@@ -349,13 +349,23 @@ def _extract_text(ocr_result: Any) -> str:
             text_value = current.get("text")
             if text_value is not None:
                 _append_text_value(text_value, pieces, queue)
+                continue
+
+            # บางเวอร์ชันของ RapidOCR คืนผลในคีย์อื่น เช่น 'res' หรือ 'result'
+            for key in ("texts", "txts", "res", "result", "results", "data", "value", "values"):
+                if key in current and current[key] is not None:
+                    _append_text_value(current[key], pieces, queue)
+                    break
+            else:
+                # เมื่อไม่พบคีย์ที่รู้จัก ให้ต่อคิวค่าที่ไม่เป็น None เพื่อพยายามแยกข้อความต่อไป
+                queue.extend(v for v in current.values() if v is not None)
             continue
         text_attr = getattr(current, "text", None)
         if text_attr is not None:
             handled = _append_text_value(text_attr, pieces, queue)
             if handled:
                 continue
-        for attr_name in ("texts", "txts"):
+        for attr_name in ("texts", "txts", "res", "result", "results", "data", "value", "values"):
             if hasattr(current, attr_name):
                 attr_value = getattr(current, attr_name)
                 if attr_value is not None:

--- a/tests/test_rapid_ocr_result_parsing.py
+++ b/tests/test_rapid_ocr_result_parsing.py
@@ -48,3 +48,17 @@ def test_rapid_ocr_accepts_object_with_txts(monkeypatch):
     frame = np.zeros((10, 10, 3), dtype=np.uint8)
     ocr.process(frame, roi_id='3', save=False, source='', interval=0)
     assert ocr.last_ocr_results['3'] == '329'
+
+
+def test_rapid_ocr_accepts_dict_res_key(monkeypatch):
+    ocr = RapidOCR()
+    ocr.last_ocr_results.clear()
+
+    class DummyReader:
+        def __call__(self, frame):
+            return {"res": [{"text": "rapid"}, {"text": "ocr"}]}
+
+    monkeypatch.setattr(ocr, '_get_reader', lambda: DummyReader())
+    frame = np.zeros((10, 10, 3), dtype=np.uint8)
+    ocr.process(frame, roi_id='4', save=False, source='', interval=0)
+    assert ocr.last_ocr_results['4'] == 'rapid ocr'


### PR DESCRIPTION
## Summary
- handle RapidOCR outputs that return recognized text under alternative keys such as `res`, `result`, or `data`
- keep traversing nested dictionary values so text is no longer dropped during normalization
- add a regression test covering a `res` keyed response

## Testing
- pytest tests/test_rapid_ocr_result_parsing.py -q

------
https://chatgpt.com/codex/tasks/task_e_68d752260aa4832bb30925692ad96d00