### PR TITLE
Prevent inference stream latency buildup on slow networks

### DIFF
--- a/tests/test_camera_worker_resolution.py
+++ b/tests/test_camera_worker_resolution.py
@@ -36,3 +36,19 @@ def test_camera_worker_sets_resolution():
         app.cv2.VideoCapture = orig_vc
         app.cv2.CAP_PROP_FRAME_WIDTH = orig_w
         app.cv2.CAP_PROP_FRAME_HEIGHT = orig_h
+
+
+def test_camera_worker_low_latency_env(monkeypatch):
+    import camera_worker
+
+    monkeypatch.delenv("CAMERA_FFMPEG_LOW_LATENCY", raising=False)
+    assert camera_worker.CameraWorker._resolve_low_latency(None) is True
+
+    monkeypatch.setenv("CAMERA_FFMPEG_LOW_LATENCY", "0")
+    assert camera_worker.CameraWorker._resolve_low_latency(None) is False
+
+    monkeypatch.setenv("CAMERA_FFMPEG_LOW_LATENCY", "yes")
+    assert camera_worker.CameraWorker._resolve_low_latency(None) is True
+
+    assert camera_worker.CameraWorker._resolve_low_latency(False) is False
+    assert camera_worker.CameraWorker._resolve_low_latency(True) is True

--- a/tests/test_read_and_queue_frame.py
+++ b/tests/test_read_and_queue_frame.py
@@ -24,7 +24,7 @@ def test_read_and_queue_frame_skip_on_none():
 
     app.cv2.imencode = fake_imencode
 
-    async def processor(frame):
+    async def processor(frame, frame_time):
         return None
 
     asyncio.run(app.read_and_queue_frame("0", q, processor))


### PR DESCRIPTION
## Summary
- drop queued video frames when the websocket connection falls behind to avoid compounding delay
- keep non-video websocket messages intact while prioritising the latest frame
- track capture timestamps for video frames and discard stale packets before sending to keep long-running streams current
- default ffmpeg camera workers to low-latency mode (configurable via `CAMERA_FFMPEG_LOW_LATENCY`) and drop unused apply settings arguments

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d774ea0f90832bb5424f8da3102a09