### PR TITLE
Add rapidocr_onnxruntime dependency to project

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,7 @@ VisionROI/
 - `Pillow`
 - `easyocr`
 - `rapidocr`
+- `rapidocr_onnxruntime`
 - `pytesseract`
 - `paho-mqtt`
 - `requests`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ dependencies = [
     "Pillow",
     "easyocr",
     "rapidocr",
+    "rapidocr_onnxruntime",
     "pytesseract",
     "paho-mqtt",
     "requests",


### PR DESCRIPTION
## Summary
- add rapidocr_onnxruntime to the core dependency list
- update README to document the new requirement

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d7ea585b2c832ba0ea340e9dc557dd