### PR TITLE
Improve ffmpeg streaming robustness and provide OpenCV stub fallback

### DIFF
--- a/app.py
+++ b/app.py
@@ -3,8 +3,7 @@ faulthandler.enable()
 
 from quart import Quart, render_template, websocket, request, jsonify, redirect, Response
 import asyncio
-import cv2
-from camera_worker import CameraWorker
+from camera_worker import CameraWorker, cv2
 try:
     import numpy as np
 except Exception:
@@ -2124,7 +2123,7 @@ async def start_camera_task(
             src = camera_sources.get(cam_id, 0)
             width, height = camera_resolutions.get(cam_id, (None, None))
             backend = camera_backends.get(cam_id, "opencv")
-            worker_low_latency = bool(low_latency) if low_latency is not None else False
+            worker_low_latency = bool(low_latency) if low_latency is not None else True
             worker = CameraWorker(
                 src,
                 asyncio.get_running_loop(),


### PR DESCRIPTION
## Summary
- provide a shared cv2 stub so the application can start even when OpenCV binaries are unavailable
- enable low-latency mode by default for ffmpeg streams and refactor process spawning to reduce buffering and delays
- tighten ffmpeg command options and restart logic so reconnects stay robust while minimizing memory usage

## Testing
- pytest tests/test_camera_worker_read_timeout.py
- pytest tests/test_camera_worker_resolution.py
- pytest tests/test_event_loop.py

------
https://chatgpt.com/codex/tasks/task_e_68d882d55630832b90006d827ecbdb24