### PR TITLE
Fix ROI column duplication after auto start

### DIFF
--- a/templates/partials/inference_content.html
+++ b/templates/partials/inference_content.html
@@ -486,10 +486,37 @@
             return (data?.type ?? 'roi') === 'roi';
         }
 
-        function ensureRoiItem(id) {
+        function normalizeGroupName(value) {
+            return typeof value === 'string' ? value.trim() : '';
+        }
+
+        function getRoiGroupName(roi) {
+            return normalizeGroupName(roi?.group ?? roi?.page ?? roi?.name ?? '');
+        }
+
+        function roiMatchesActiveGroup(data) {
+            if (!isRoiType(data)) {
+                return false;
+            }
+            const activeGroup = normalizeGroupName(lastActiveGroup);
+            if (!activeGroup) {
+                return rois.some(r => String(r?.id) === String(data?.id));
+            }
+            if (activeGroup === 'all') {
+                return true;
+            }
+            return getRoiGroupName(data) === activeGroup;
+        }
+
+        function ensureRoiItem(id, roiData = null) {
             if (document.getElementById(`${cellId}-roi-${id}`)) return;
-            const r = findRoiDataById(id) || { id };
-            if (!isRoiType(r)) {
+            const key = String(id);
+            const r =
+                roiData
+                || rois.find(entry => String(entry?.id) === key)
+                || findRoiDataById(id)
+                || null;
+            if (!r || !roiMatchesActiveGroup(r)) {
                 return;
             }
             const item = document.createElement('div');
@@ -523,10 +550,10 @@
             const roiId = result.id;
             if (roiId === undefined || roiId === null) return;
             const roiData = findRoiDataById(roiId);
-            if (roiData && !isRoiType(roiData)) {
+            if (!roiData || !roiMatchesActiveGroup(roiData)) {
                 return;
             }
-            ensureRoiItem(roiId);
+            ensureRoiItem(roiId, roiData);
             updateRoiModuleLabel(roiId, result.module);
             const imgEl = document.getElementById(`${cellId}-roi-${roiId}`);
             if (imgEl && Object.prototype.hasOwnProperty.call(result, 'image')) {
@@ -734,6 +761,7 @@
             const activeGroup = loadGroupOptions(roiList, selectedGroupName);
             const groupToUse = selectedGroupName || activeGroup;
             const requestGroup = groupToUse || null;
+            lastActiveGroup = groupToUse || '';
             if (Array.isArray(roisOverride)) {
                 rois = roisOverride;
             } else if (groupToUse === 'all') {
@@ -746,7 +774,7 @@
             roiGrid.innerHTML = '';
             rois.forEach(r => {
                 if (r && r.id !== undefined && r.id !== null) {
-                    ensureRoiItem(r.id);
+                    ensureRoiItem(r.id, r);
                     updateRoiModuleLabel(r.id);
                 }
             });
@@ -786,7 +814,6 @@
                 return;
             }
             statusEl.innerText = 'สำเร็จ';
-            lastActiveGroup = groupToUse || '';
             openSocket();
             if (rois.length > 0) {
                 openRoiSocket();
@@ -1035,6 +1062,7 @@
                 const normalizedStatusGroup = typeof statusGroup === 'string' ? statusGroup : '';
                 const activeGroup = loadGroupOptions(roiList, normalizedStatusGroup);
                 const groupToUse = (normalizedStatusGroup || activeGroup || '').trim();
+                lastActiveGroup = groupToUse || '';
                 if (groupToUse === 'all') {
                     rois = roiList;
                 } else if (groupToUse) {
@@ -1045,11 +1073,10 @@
                 roiGrid.innerHTML = '';
                 rois.forEach(r => {
                     if (r && r.id !== undefined && r.id !== null) {
-                        ensureRoiItem(r.id);
+                        ensureRoiItem(r.id, r);
                         updateRoiModuleLabel(r.id);
                     }
                 });
-                lastActiveGroup = groupToUse || '';
                 if (roiSocket) {
                     roiSocket.close();
                     roiSocket = null;

--- a/templates/partials/inference_page_content.html
+++ b/templates/partials/inference_page_content.html
@@ -398,7 +398,7 @@
         rois = list;
         list.forEach(r => {
           if (r && r.id !== undefined && r.id !== null) {
-            ensureRoiItem(r.id);
+            ensureRoiItem(r.id, r);
             updateRoiModuleLabel(r.id);
           }
         });
@@ -546,13 +546,18 @@
         return (data?.type ?? 'roi') === 'roi';
       }
 
-      function ensureRoiItem(id) {
+      function ensureRoiItem(id, roiData = null) {
         if (!activeGroupName) {
           return;
         }
         if (document.getElementById(`${cellId}-roi-${id}`)) return;
-        const r = findRoiDataById(id) || { id };
-        if (!isRoiType(r)) {
+        const key = String(id);
+        const r =
+          roiData
+          || rois.find(entry => String(entry?.id) === key)
+          || findRoiDataById(id)
+          || null;
+        if (!r || !isRoiType(r)) {
           return;
         }
         if (getRoiGroupName(r) !== activeGroupName) {
@@ -589,10 +594,13 @@
         const roiId = result.id;
         if (roiId === undefined || roiId === null) return;
         const roiData = findRoiDataById(roiId);
-        if (roiData && !isRoiType(roiData)) {
+        if (!roiData || !isRoiType(roiData)) {
           return;
         }
-        ensureRoiItem(roiId);
+        if (getRoiGroupName(roiData) !== activeGroupName) {
+          return;
+        }
+        ensureRoiItem(roiId, roiData);
         updateRoiModuleLabel(roiId, result.module);
         const imgEl = document.getElementById(`${cellId}-roi-${roiId}`);
         if (imgEl && Object.prototype.hasOwnProperty.call(result, 'image')) {


### PR DESCRIPTION
## Summary
- prevent the inference ROI panels from creating tiles for results that are not part of the active group
- reuse cached ROI metadata when rendering tiles so the module label and title stay in sync
- update both inference pages to set the current group before drawing the ROI list

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68da0f6c117c832b8bb563ff1d46d1e8