### PR TITLE
Log MQTT messages per source ROI

### DIFF
--- a/src/utils/logger.py
+++ b/src/utils/logger.py
@@ -1,12 +1,13 @@
 from __future__ import annotations
 
 import logging
+import re
 from logging.handlers import TimedRotatingFileHandler
 from pathlib import Path
 import threading
 
 _formatter = logging.Formatter("%(asctime)s - %(levelname)s - %(message)s")
-_loggers: dict[tuple[str, str], logging.Logger] = {}
+_loggers: dict[tuple[str, str, str], logging.Logger] = {}
 _lock = threading.Lock()
 
 _SUPPRESS_INFO_MODULES = {
@@ -35,10 +36,25 @@ _DATA_SOURCES_ROOT = Path(__file__).resolve().parents[2] / "data_sources"
 _INFERENCE_ROOT = Path(__file__).resolve().parents[2] / "inference_modules"
 
 
-def get_logger(module_name: str, source: str | None = None) -> logging.Logger:
+def _normalize_log_filename(name: str | None) -> str:
+    if not name:
+        return "custom.log"
+    sanitized = re.sub(r"[^\w.-]+", "_", name.strip())
+    sanitized = sanitized.strip("._")
+    if not sanitized:
+        sanitized = "custom"
+    if not sanitized.lower().endswith(".log"):
+        sanitized = f"{sanitized}.log"
+    return sanitized
+
+
+def get_logger(
+    module_name: str, source: str | None = None, log_name: str | None = None
+) -> logging.Logger:
     """คืน logger ที่ตั้งค่า handler ตาม module และ source"""
     src = source or ""
-    key = (module_name, src)
+    filename = _normalize_log_filename(log_name)
+    key = (module_name, src, filename)
     logger = _loggers.get(key)
     if logger is not None:
         return logger
@@ -59,7 +75,7 @@ def get_logger(module_name: str, source: str | None = None) -> logging.Logger:
             log_dir = _INFERENCE_ROOT / module_name
         log_dir.mkdir(parents=True, exist_ok=True)
         handler = TimedRotatingFileHandler(
-            str(log_dir / "custom.log"), when="D", interval=1, backupCount=7
+            str(log_dir / filename), when="D", interval=1, backupCount=7
         )
         handler.setFormatter(_formatter)
         if module_name in _SUPPRESS_INFO_MODULES:


### PR DESCRIPTION
## Summary
- update the shared logger utility to support custom log filenames per module/source and sanitize ROI names
- write MQTT logs into `data_sources/<source>/<roi_name>.log` by choosing ROI-specific loggers when publishing
- add regression coverage to ensure MQTT logs are created in the source folder and update existing cleanup for new logger keys

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68da1781ce74832baa77116ea3e525ed